### PR TITLE
feat: token-based authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # This is the dimension of the vector embedding of the database.
 # All supplied vectors must have this dimension.
 OASYSDB_DIMENSION=number
+OASYSDB_TOKEN=string
 
 # Optional variables.
 # Modify the port the server listens on. Default to 3141.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -56,6 +56,16 @@ For commit messages, we use the [Conventional Commits](https://www.conventionalc
 
 For commenting your code, please try your best to write comments that are clear and concise with proper English sentence capitalization and punctuation. This will help us and the community understand your code better and keep the codebase maintainable.
 
+## Local Docker development
+
+As an alternative to using Rust, you can use Docker to run OasysDB locally. First, run the following command:
+
+```bash
+docker build -t oasysdb .
+```
+
+This will build the Docker image for OasysDB which you can then run locally. If you need guidance on how to run OasysDB locally, please refer to this [documentation](/readme.md#with-docker).
+
 ## Submitting a pull request
 
 Once you have made your changes, you can submit a pull request. We will review your pull request and provide feedback. If your pull request is accepted, we will merge it into the main branch.

--- a/readme.md
+++ b/readme.md
@@ -20,11 +20,15 @@ This will pull the latest version of the server from the GitHub Container Regist
 docker run \
     --platform linux/amd64 \
     --publish 3141:3141 \
-    --env OASYSDB_DIMENSION=xxx \
+    --env OASYSDB_DIMENSION=512 \
+    --env OASYSDB_TOKEN=token \
     ghcr.io/oasysai/oasysdb:latest
 ```
 
-Replace `xxx` with the dimension of your desired embedding. This will start the server on port `3141`.
+- `OASYSDB_DIMENSION`: An integer representing the dimension of your embedding. Different embedding model will have different dimension. For example, OpenAI Ada 2 has a dimension of 1536.
+- `OASYSDB_TOKEN`: A string that you will use to authenticate with the server. You need to add `x-oasysdb-token` header to your request with the value of this environment variable.
+
+This will start OasysDB that is accessible on port `3141`. You can change this by changing the port number in the `--publish` flag and setting the `OASYSDB_PORT` environment variable to the port number that you want to use.
 
 ### Testing the server
 

--- a/src/db/routes/mod.rs
+++ b/src/db/routes/mod.rs
@@ -1,7 +1,12 @@
-pub mod index;
-pub mod root;
-pub mod values;
-pub mod version;
+use super::utils::response as res;
+use super::utils::stream;
+use crate::db::server::Server;
+use tokio::net::TcpStream;
+
+mod index;
+mod root;
+mod values;
+mod version;
 
 // In this module, we define the route handlers
 // for the database server HTTP API.
@@ -19,3 +24,54 @@ pub mod version;
 // Example: get, post, put, delete, etc.
 //
 // Note: Avoid wildcard imports.
+
+pub async fn handle_connection(server: &mut Server, stream: &mut TcpStream) {
+    loop {
+        handle_request(server, stream).await;
+    }
+}
+
+async fn handle_request(server: &mut Server, stream: &mut TcpStream) {
+    // Read request from the client.
+    let _req = stream::read(stream).await;
+
+    // Handle disconnection or invalid request.
+    // Return invalid request response.
+    if _req.is_none() {
+        let response = res::get_error_response(400, "Invalid request.");
+        stream::write(stream, response).await;
+        return;
+    }
+
+    // Unwrap the data.
+    let request = _req.as_ref().unwrap();
+    let route = request.route.clone();
+
+    // Check if the route is private.
+    // Private routes require authentication.
+    let private_routes = ["/index", "/values"];
+    if private_routes.iter().any(|r| route.starts_with(r)) {
+        // Get the token from the request headers.
+        let token = request.headers.get("x-oasysdb-token");
+
+        // Check if the token is valid.
+        // If not, return unauthorized response.
+        if token.is_none() || token.unwrap() != &server.config.token {
+            let response = res::get_401_response();
+            stream::write(stream, response).await;
+            return;
+        }
+    }
+
+    // Get response based on different routes and methods.
+    let response = match route.as_str() {
+        "/" => root::handler(request),
+        "/version" => version::handler(request),
+        _ if route.starts_with("/index") => index::handler(server, request),
+        _ if route.starts_with("/values") => values::handler(server, request),
+        _ => res::get_404_response(),
+    };
+
+    // Write the data back to the client.
+    stream::write(stream, response).await;
+}

--- a/src/db/utils/response.rs
+++ b/src/db/utils/response.rs
@@ -16,9 +16,13 @@ pub fn get_error_response(code: u16, message: &str) -> Response<String> {
     create_response(code, Some(body))
 }
 
-// Generic empty error responses.
-// This is useful for routes that don't need to return
-// a body and has a canonical status code.
+// Generic error responses.
+// These are useful for streamlining the error handling.
+
+pub fn get_401_response() -> Response<String> {
+    let message = "Invalid x-oasysdb-token header.";
+    get_error_response(401, message)
+}
 
 pub fn get_405_response() -> Response<String> {
     create_response(405, None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,11 @@ async fn main() {
     let dimension = env_get_dimension();
 
     // Create the server configuration.
-    let config = Config { dimension };
+    let config = {
+        // The token used to authenticate requests to the server.
+        let token = get_env("OASYSDB_TOKEN");
+        Config { dimension, token }
+    };
 
     // Display the server configuration.
     println!("OasysDB is running on port {}.", port);
@@ -27,11 +31,15 @@ async fn main() {
     server.serve().await;
 }
 
+// Utility functions.
+// Helper functions to get the server running.
+
 fn env_get_dimension() -> usize {
-    let not_set = "env variable 'OASYSDB_DIMENSION' required";
     let not_int = "variable 'OASYSDB_DIMENSION' must be an integer";
-    env::var("OASYSDB_DIMENSION")
-        .expect(not_set)
-        .parse::<usize>()
-        .expect(not_int)
+    get_env("OASYSDB_DIMENSION").parse::<usize>().expect(not_int)
+}
+
+fn get_env(key: &str) -> String {
+    let not_set = format!("env variable '{}' required", key);
+    env::var(key).expect(&not_set)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use oasysdb::db::server::{Config, Server, Value};
 use rand::random;
+use reqwest::header::HeaderMap;
 use std::collections::HashMap;
 use tokio::runtime::Runtime;
 
@@ -15,7 +16,7 @@ pub async fn run_server(port: String) -> Runtime {
         let port = port.as_str();
 
         // Server configuration.
-        let config = Config { dimension: 2 };
+        let config = Config { dimension: 2, token: "token".to_string() };
 
         // Create a new server.
         let mut server = Server::new(host, port, config);
@@ -48,4 +49,11 @@ pub async fn run_server(port: String) -> Runtime {
 pub async fn stop_server(runtime: Runtime) {
     // Shutdown the runtime.
     runtime.shutdown_background();
+}
+
+pub fn get_headers() -> HeaderMap {
+    // Generate headers for the test requests.
+    let mut headers = HeaderMap::new();
+    headers.insert("x-oasysdb-token", "token".parse().unwrap());
+    headers
 }

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use common::{run_server, stop_server};
-use reqwest::{get, Client};
+use common::{get_headers, run_server, stop_server};
+use reqwest::Client;
 
 // Test server host.
 const HOST: &str = "http://127.0.0.1";
@@ -15,7 +15,7 @@ const CREATE_VALUE: &str = r#"{
     "value": {"embedding": [0.0, 0.0], "data": {}}
 }"#;
 
-const QUERY: &str = r#"{
+const QUERY_INDEX: &str = r#"{
     "embedding": [0.0, 0.0],
     "count": 5
 }"#;
@@ -28,72 +28,87 @@ const QUERY: &str = r#"{
 #[tokio::test]
 async fn test_get_root() {
     let port = String::from("31400");
-    let url = format!("{}:{}", HOST, port);
-    let runtime = run_server(port).await;
+    let runtime = run_server(port.clone()).await;
 
     // Make a get request to the root.
-    let res = get(url).await.unwrap();
-    assert_eq!(res.status(), 200);
+    let client = Client::new();
+    let url = format!("{}:{}", HOST, port);
+    let response = client.get(&url).send().await.unwrap();
+
+    assert_eq!(response.status(), 200);
     stop_server(runtime).await;
 }
 
 #[tokio::test]
 async fn test_post_values() {
     let port = String::from("31401");
+    let runtime = run_server(port.clone()).await;
+
+    // Create a key-value pair.
+    let headers = get_headers();
     let url = format!("{}:{}/values", HOST, port);
-    let runtime = run_server(port).await;
 
-    // Make a post request to create key-value store.
     let client = Client::new();
-    let res = client.post(&url).body(CREATE_VALUE).send().await.unwrap();
+    let response = client
+        .post(&url)
+        .headers(headers)
+        .body(CREATE_VALUE)
+        .send()
+        .await
+        .unwrap();
 
-    assert_eq!(res.status(), 201);
+    assert_eq!(response.status(), 201);
     stop_server(runtime).await;
 }
 
 #[tokio::test]
 async fn test_get_values() {
     let port = String::from("31402");
+    let runtime = run_server(port.clone()).await;
 
     // The key-0 is pre-populated for testing.
     let url = format!("{}:{}/values/key-0", HOST, port);
 
-    let runtime = run_server(port).await;
-
     // Call GET to get the value of the key.
-    let res = get(url).await.unwrap();
-    assert_eq!(res.status(), 200);
+    let headers = get_headers();
+    let client = Client::new();
+    let response = client.get(url).headers(headers).send().await.unwrap();
+
+    assert_eq!(response.status(), 200);
     stop_server(runtime).await;
 }
 
 #[tokio::test]
 async fn test_delete_values() {
     let port = String::from("31403");
+    let runtime = run_server(port.clone()).await;
 
     // The key-5 is pre-populated when the server is started.
     let url = format!("{}:{}/values/key-5", HOST, port);
 
-    let runtime = run_server(port).await;
-
     // Use DELETE to delete the key-value pair.
+    let headers = get_headers();
     let client = Client::new();
-    let res = client.delete(&url).send().await.unwrap();
+    let response = client.delete(&url).headers(headers).send().await.unwrap();
 
     // Assert for 204 status code.
-    assert_eq!(res.status(), 204);
+    assert_eq!(response.status(), 204);
     stop_server(runtime).await;
 }
 
 #[tokio::test]
 async fn test_post_index() {
     let port = String::from("31404");
-    let url = format!("{}:{}/index", HOST, port);
-    let runtime = run_server(port).await;
-    let client = Client::new();
+    let runtime = run_server(port.clone()).await;
 
     // This is a POST request with no body as for this endpoint,
     // the body is optional: ef_search and ef_construction.
-    let res = client.post(&url).send().await.unwrap();
+    let url = format!("{}:{}/index", HOST, port);
+    let headers = get_headers();
+
+    let client = Client::new();
+    let res = client.post(&url).headers(headers).send().await.unwrap();
+
     assert_eq!(res.status(), 200);
     stop_server(runtime).await;
 }
@@ -101,13 +116,21 @@ async fn test_post_index() {
 #[tokio::test]
 async fn test_post_index_query() {
     let port = String::from("31405");
-    let url = format!("{}:{}/index/query", HOST, port);
-    let runtime = run_server(port).await;
+    let runtime = run_server(port.clone()).await;
 
     // The body embedding is required and the dimension
     // must match the dimension specified in the config.
+    let headers = get_headers();
+    let url = format!("{}:{}/index/query", HOST, port);
+
     let client = Client::new();
-    let res = client.post(&url).body(QUERY).send().await.unwrap();
+    let res = client
+        .post(&url)
+        .headers(headers)
+        .body(QUERY_INDEX)
+        .send()
+        .await
+        .unwrap();
 
     assert_eq!(res.status(), 200);
     stop_server(runtime).await;


### PR DESCRIPTION
### Purpose

This PR adds a layer of HTTP authentication before performing actions to the database via the endpoints. This authentication is applied only for `/index` and `/values` routes.

### Approach

This PR add a feature that will get `x-oasysdb-token` header from the request and match it against the `OASYSDB_TOKEN` environment variable used to run the server. If the token doesn't match, the server will return a 401 unauthorized response.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I tested this PR by running `cargo test` and manually checking functionality by calling the endpoints directly from Insomnia. There is no new tests being added to the test suite. But, I added functionality to the existing tests to guard for unauthorized request without or invalid `x-oasysdb-token`.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
