### PR TITLE
fix: fix server multithreading

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,5 @@
+pub mod routes;
 pub mod server;
 
 // Private modules.
-mod routes;
 mod utils;

--- a/src/db/routes/index.rs
+++ b/src/db/routes/index.rs
@@ -3,10 +3,7 @@ use crate::db::utils::request::{Request, RequestBody};
 use crate::db::utils::response as res;
 use std::collections::HashMap;
 
-pub fn handler(
-    server: &mut Server,
-    request: &Request,
-) -> res::Response<String> {
+pub fn handler(server: &Server, request: &Request) -> res::Response<String> {
     // Index-related routes only accept POST requests.
     if request.method != "post" {
         return res::get_405_response();
@@ -21,7 +18,7 @@ pub fn handler(
     }
 }
 
-fn post_index(server: &mut Server, body: RequestBody) -> res::Response<String> {
+fn post_index(server: &Server, body: RequestBody) -> res::Response<String> {
     // Get optional build parameters from the body.
     // EF search is maximum number of candidate neighbors
     // to be considered during search.
@@ -55,7 +52,7 @@ fn post_index(server: &mut Server, body: RequestBody) -> res::Response<String> {
 }
 
 fn post_index_query(
-    server: &mut Server,
+    server: &Server,
     body: RequestBody,
 ) -> res::Response<String> {
     // Validate that embedding is in the body.

--- a/src/db/routes/mod.rs
+++ b/src/db/routes/mod.rs
@@ -25,13 +25,7 @@ mod version;
 //
 // Note: Avoid wildcard imports.
 
-pub async fn handle_connection(server: &mut Server, stream: &mut TcpStream) {
-    loop {
-        handle_request(server, stream).await;
-    }
-}
-
-async fn handle_request(server: &mut Server, stream: &mut TcpStream) {
+pub async fn handle_request(server: &Server, stream: &mut TcpStream) {
     // Read request from the client.
     let _req = stream::read(stream).await;
 

--- a/src/db/routes/values.rs
+++ b/src/db/routes/values.rs
@@ -2,10 +2,7 @@ use crate::db::server::{Server, Value};
 use crate::db::utils::request::{Request, RequestBody};
 use crate::db::utils::response as res;
 
-pub fn handler(
-    server: &mut Server,
-    request: &Request,
-) -> res::Response<String> {
+pub fn handler(server: &Server, request: &Request) -> res::Response<String> {
     let route = request.route.clone();
     let body = request.body.clone();
     match request.method.as_str() {
@@ -45,7 +42,7 @@ fn get(server: &Server, route: String) -> res::Response<String> {
     res::create_response(200, Some(body))
 }
 
-fn post(server: &mut Server, body: RequestBody) -> res::Response<String> {
+fn post(server: &Server, body: RequestBody) -> res::Response<String> {
     // If request body is missing key or value.
     if body.get("key").is_none() || body.get("value").is_none() {
         let message = "Both key and value are required.";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,29 @@
 pub mod db;
 
+use crate::db::routes::handle_request;
+use crate::db::server::{Config, Server};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
 #[macro_use]
 extern crate serde_derive;
+
+pub async fn serve(host: &str, port: &str, config: Config) {
+    // Create a new server with Arc to share the
+    // server reference across threads.
+    let server = Arc::new(Server::new(config));
+
+    // Parse the host and port into a SocketAddr.
+    let addr: SocketAddr = format!("{}:{}", host, port).parse().unwrap();
+    let listener = TcpListener::bind(addr).await.unwrap();
+
+    loop {
+        // Accept and handle requests from clients.
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let server = server.clone();
+        tokio::spawn(async move {
+            handle_request(&server, &mut stream).await;
+        });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use dotenv::dotenv;
-use oasysdb::db::server::{Config, Server};
+use oasysdb::db::server::Config;
+use oasysdb::serve;
 use std::env;
 
 #[tokio::main]
@@ -27,8 +28,7 @@ async fn main() {
 
     // Create and start the server.
     let host = "0.0.0.0";
-    let mut server = Server::new(host, port.as_str(), config);
-    server.serve().await;
+    serve(host, &port, config).await;
 }
 
 // Utility functions.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,10 @@
+use oasysdb::db::routes::handle_request;
 use oasysdb::db::server::{Config, Server, Value};
 use rand::random;
 use reqwest::header::HeaderMap;
 use std::collections::HashMap;
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
 
 pub async fn run_server(port: String) -> Runtime {
@@ -14,12 +17,17 @@ pub async fn run_server(port: String) -> Runtime {
         // Server parameters.
         let host = "127.0.0.1";
         let port = port.as_str();
+        let addr: SocketAddr = format!("{}:{}", host, port).parse().unwrap();
 
-        // Server configuration.
+        // Create a TCP listener to accept connections.
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let (mut stream, _) = listener.accept().await.unwrap();
+
+        // Server configuration for testing only.
         let config = Config { dimension: 2, token: "token".to_string() };
 
         // Create a new server.
-        let mut server = Server::new(host, port, config);
+        let server = Server::new(config);
 
         // Pre-populate the key-value store.
         for i in 0..9 {
@@ -39,7 +47,7 @@ pub async fn run_server(port: String) -> Runtime {
         server.build(ef, ef).unwrap();
 
         // Start the server.
-        server.serve().await;
+        handle_request(&server, &mut stream).await;
     });
 
     // Return runtime as a handle to stop the server.


### PR DESCRIPTION
### Purpose

This PR solves the issue where the server doesn't acccept multiple connections/requests at once. It will throw connection refused error or even sometimes crash the server.

### Approach

1. I modified the server in a way to prevent direct mutation to the server by using `Arc` and `Mutex` for shared values.
2. I fixed the `tokio::spawn` code which is the primary source of this problem.
3. I remove the `Server.serve()` function and replace it with a standalone `serve` function that will handle the server and thread creation. In this function, the server is wrapped by `Arc` to allow threads to refer to the same server.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I have modified the test suite to accomodate the changes that I made to the server functionality.

I tested this PR by using a custom Python script to create a multi-threaded request to the server while the server is running on localhost port 3141. Without this changes, the server will throw an error when encountering multi-thread requests.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
