### PR TITLE
fix: increase read buffer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,18 @@
 # Required variables.
+# ==========
+
 # This is the dimension of the vector embedding of the database.
 # All supplied vectors must have this dimension.
 OASYSDB_DIMENSION=number
+
+# Token used for requests to authenticate with the server.
 OASYSDB_TOKEN=string
 
 # Optional variables.
+# ==========
+
 # Modify the port the server listens on. Default to 3141.
 OASYSDB_PORT=number
+
+# Read buffer size of the server. Default is 32KB.
+OASYSDB_BUFFER_SIZE=number

--- a/src/db/utils/stream.rs
+++ b/src/db/utils/stream.rs
@@ -1,16 +1,25 @@
 use super::request::{Request, RequestHeaders};
 use super::response::Response;
 use std::collections::HashMap;
+use std::env;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
 pub async fn read(stream: &mut TcpStream) -> Option<Request> {
+    // Allow the buffer size to be set via environment variable.
+    // The default buffer size is 32KB which is large enough
+    // for 1536 dimensions embeddings.
+    let buffer_size = env::var("OASYSDB_BUFFER_SIZE")
+        .unwrap_or(String::from("32768"))
+        .parse::<usize>()
+        .unwrap();
+
     // Prepare the request for parsing.
     let mut _headers = [httparse::EMPTY_HEADER; 16];
     let mut _req = httparse::Request::new(&mut _headers);
 
     // Read data from the stream.
-    let mut buf = vec![0; 1024];
+    let mut buf = vec![0; buffer_size];
     let n = stream.read(&mut buf).await.unwrap();
 
     // Disconnection handler.


### PR DESCRIPTION
### Purpose

This PR introduce a flexible configuration to configure read buffer for the TCP stream. It was initially set on 1024 which is not enough to read full length body of high-dimensional embeddings (tested using 512 and 1536 dimensions embedding).

### Approach

Added an environment variable `OASYSDB_BUFFER_SIZE` that will define the read buffer size for when reading data from stream. By default, this is set to 32768 (enough to read 1536 dimension embedding created by Python `random.random()` function).

This environment variable allows users who use lower dimensional embedding to set the buffer size lower to optimize the performance.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

Tested this PR using a Python script to generate the embedding and calling the `POST /values` endpoint to create a new value. I didn't add anything to the test suite as making a custom body for the request is time consuming. 

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
