### PR TITLE
fix: post values remove response body

### DIFF
--- a/src/db/routes/values.rs
+++ b/src/db/routes/values.rs
@@ -79,13 +79,7 @@ fn post(server: &Server, body: RequestBody) -> res::Response<String> {
         return res::get_error_response(400, message);
     }
 
-    // Serialize value as string for the response.
-    let body = {
-        let _val = result.unwrap();
-        serde_json::to_string(&_val).unwrap()
-    };
-
-    res::create_response(201, Some(body))
+    res::create_response(201, None)
 }
 
 fn delete(server: &Server, route: String) -> res::Response<String> {


### PR DESCRIPTION
### Purpose

This PR will remove returning the value which contains embedding and data when creating a new key-value pair because it's redundant. For high-dimensional embeddings, this will cause extra overhead to write response back to the client.

### Approach

Delete the part of code that constructs and returns the body for the response. Instead, we return `None` for the body with code 201 which is the same as previously.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I have tested this PR manually using Insomnia to make a request to POST `/values` which after this change will return an empty object.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
