### PR TITLE
feat: database persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,10 @@
+# Configurable environment variables for OasysDB.
+# Check the documentation for more information.
+
 # Required variables.
-# ==========
-
-# This is the dimension of the vector embedding of the database.
-# All supplied vectors must have this dimension.
 OASYSDB_DIMENSION=number
-
-# Token used for requests to authenticate with the server.
 OASYSDB_TOKEN=string
 
 # Optional variables.
-# ==========
-
-# Modify the port the server listens on. Default to 3141.
 OASYSDB_PORT=number
-
-# Read buffer size of the server. Default is 32KB.
 OASYSDB_BUFFER_SIZE=number

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # OasysDB.
 data
+tests/data
 
 # Rust stuff.
 debug

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OasysDB.
+data
+
 # Rust stuff.
 debug
 target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +104,15 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -206,6 +221,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +267,15 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -395,6 +429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "instant-distance"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,7 +445,7 @@ checksum = "8c619cdaa30bb84088963968bee12a45ea5fbbf355f2c021bcd15589f5ca494a"
 dependencies = [
  "num_cpus",
  "ordered-float",
- "parking_lot",
+ "parking_lot 0.12.1",
  "rand",
  "rayon",
 ]
@@ -553,6 +596,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sled",
  "tokio",
 ]
 
@@ -626,12 +670,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -642,7 +711,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -743,6 +812,15 @@ checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -917,6 +995,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,7 +1076,7 @@ checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -1013,7 +1107,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_derive = "1.0.193"
 rand = "0.8.5"
 instant-distance = "0.6.1"
 dotenv = "0.15.0"
+sled = "0.34.7"
 
 [profile.release]
 lto = true

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ docker run \
 ```
 
 - `OASYSDB_DIMENSION`: An integer representing the dimension of your embedding. Different embedding model will have different dimension. For example, OpenAI Ada 2 has a dimension of 1536.
+
 - `OASYSDB_TOKEN`: A string that you will use to authenticate with the server. You need to add `x-oasysdb-token` header to your request with the value of this environment variable.
 
 This will start OasysDB that is accessible on port `3141`. You can change this by changing the port number in the `--publish` flag and setting the `OASYSDB_PORT` environment variable to the port number that you want to use.
@@ -112,6 +113,22 @@ If, for example, your value's data contains `text` and `source` information, thi
   }
 ]
 ```
+
+## Environment configuration
+
+When starting OasysDB, you can configure the server by setting the environment variables. There are required variables that you need to set to get the server running and there are also optional variables that you can set to customize the server.
+
+If you're curious, every environment variables is listed in the [`.env.example`](/.env.example) file.
+
+### Required variables
+
+The required environment variables is listed in the getting started section above as they are required to get the server running.
+
+### Optional variables
+
+- `OASYSDB_PORT`: An integer of the port number that the server will listen to for requests. (Default: `3141`)
+
+- `OASYSDB_BUFFER_SIZE`: An integer representing the maximum size of the request. (Default: `32768` or 32KB)
 
 ## Disclaimer
 

--- a/src/db/server.rs
+++ b/src/db/server.rs
@@ -23,6 +23,7 @@ type Index = Arc<Mutex<Vec<HNSW<Value, String>>>>;
 pub struct Config {
     pub dimension: usize,
     pub token: String,
+    pub path: String,
 }
 
 pub struct Server {
@@ -34,7 +35,7 @@ pub struct Server {
 impl Server {
     pub fn new(config: Config) -> Server {
         let index: Index = Arc::new(Mutex::new(Vec::with_capacity(1)));
-        let db: DB = sled::open("data").unwrap();
+        let db: DB = sled::open(config.path.clone()).unwrap();
         Server { index, config, db }
     }
 

--- a/src/db/server.rs
+++ b/src/db/server.rs
@@ -1,5 +1,6 @@
 use instant_distance::HnswMap as HNSW;
 use instant_distance::{Builder, Search};
+use sled::Db as DB;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -14,10 +15,6 @@ pub struct Value {
     pub data: Data,
 }
 
-// Use Arc and Mutex to share the key-value store
-// across threads while ensuring exclusive access.
-type KeyValue = Arc<Mutex<HashMap<String, Value>>>;
-
 // Use Arc and Mutex to share the index across threads.
 // Use Vector for the index to avoid mutating the index directly.
 type Index = Arc<Mutex<Vec<HNSW<Value, String>>>>;
@@ -30,19 +27,15 @@ pub struct Config {
 
 pub struct Server {
     pub config: Config,
-    kvs: KeyValue,
     index: Index,
+    db: DB, // Storage for key-value pairs.
 }
 
 impl Server {
     pub fn new(config: Config) -> Server {
-        // Initialize a new key-value store.
-        let kvs: KeyValue = Arc::new(Mutex::new(HashMap::new()));
-
-        // Initialize index as an empty vector.
         let index: Index = Arc::new(Mutex::new(Vec::with_capacity(1)));
-
-        Server { kvs, index, config }
+        let db: DB = sled::open("data").unwrap();
+        Server { index, config, db }
     }
 
     // Native functionality handler.
@@ -51,8 +44,13 @@ impl Server {
     // Example: get, set, delete, etc.
 
     pub fn get(&self, key: String) -> Result<Value, &str> {
-        let kvs = self.kvs.lock().unwrap();
-        kvs.get(&key).cloned().ok_or("The value is not found.")
+        // Check if the key exists.
+        if !self.db.contains_key(key.clone()).unwrap() {
+            return Err("The value is not found.");
+        }
+
+        let value = self.db.get(key).unwrap().unwrap();
+        Ok(serde_json::from_slice(&value).unwrap())
     }
 
     pub fn set(&self, key: String, value: Value) -> Result<Value, &str> {
@@ -61,15 +59,34 @@ impl Server {
             return Err("The embedding dimension is invalid.");
         }
 
-        // Insert the key-value pair into the key-value store.
-        let mut kvs = self.kvs.lock().unwrap();
-        kvs.insert(key, value.clone());
+        let result = {
+            let key = key.clone();
+            let value = serde_json::to_vec(&value).unwrap();
+            self.db.insert(key, value)
+        };
+
+        if result.is_err() {
+            return Err("Error when setting the value.");
+        }
+
         Ok(value)
     }
 
     pub fn delete(&self, key: String) -> Result<Value, &str> {
-        let mut kvs = self.kvs.lock().unwrap();
-        kvs.remove(&key).ok_or("The key doesn't exist.")
+        // Check if the key exists.
+        if !self.db.contains_key(key.clone()).unwrap() {
+            return Err("The key does not exist.");
+        }
+
+        let result = {
+            let value = self.db.remove(key.clone()).unwrap().unwrap();
+            serde_json::from_slice(&value)
+        };
+
+        match result {
+            Ok(value) => Ok(value),
+            Err(_) => Err("Unable to remove the key."),
+        }
     }
 
     // Index functionality handler.
@@ -86,15 +103,15 @@ impl Server {
         let mut index = self.index.lock().unwrap();
         index.clear();
 
-        // Get the key-value store.
-        let kvs = self.kvs.lock().unwrap();
-
         // Separate key-value to keys and values.
         let mut keys = Vec::new();
         let mut values = Vec::new();
-        for (key, value) in kvs.iter() {
-            keys.push(key.clone());
-            values.push(value.clone());
+        for result in self.db.iter() {
+            let (key, value) = result.unwrap();
+            let key = String::from_utf8_lossy(&key).to_string();
+            let value: Value = serde_json::from_slice(&value).unwrap();
+            keys.push(key);
+            values.push(value);
         }
 
         // Build the index.
@@ -155,7 +172,7 @@ impl instant_distance::Point for Value {
 
         // Implement Euclidean distance formula.
         // https://en.wikipedia.org/wiki/Euclidean_distance
-        for i in 0..self.embedding.len() {
+        for i in 0..self.embedding.len().min(other.embedding.len()) {
             sum += (self.embedding[i] - other.embedding[i]).powi(2);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,8 @@ async fn main() {
     let config = {
         // The token used to authenticate requests to the server.
         let token = get_env("OASYSDB_TOKEN");
-        Config { dimension, token }
+        let path = "data".to_string();
+        Config { dimension, token, path }
     };
 
     // Display the server configuration.

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -36,7 +36,7 @@ async fn test_get_root() {
     let response = client.get(&url).send().await.unwrap();
 
     assert_eq!(response.status(), 200);
-    stop_server(runtime).await;
+    stop_server(runtime, port).await;
 }
 
 #[tokio::test]
@@ -58,7 +58,7 @@ async fn test_post_values() {
         .unwrap();
 
     assert_eq!(response.status(), 201);
-    stop_server(runtime).await;
+    stop_server(runtime, port).await;
 }
 
 #[tokio::test]
@@ -75,7 +75,7 @@ async fn test_get_values() {
     let response = client.get(url).headers(headers).send().await.unwrap();
 
     assert_eq!(response.status(), 200);
-    stop_server(runtime).await;
+    stop_server(runtime, port).await;
 }
 
 #[tokio::test]
@@ -93,7 +93,7 @@ async fn test_delete_values() {
 
     // Assert for 204 status code.
     assert_eq!(response.status(), 204);
-    stop_server(runtime).await;
+    stop_server(runtime, port).await;
 }
 
 #[tokio::test]
@@ -110,7 +110,7 @@ async fn test_post_index() {
     let res = client.post(&url).headers(headers).send().await.unwrap();
 
     assert_eq!(res.status(), 200);
-    stop_server(runtime).await;
+    stop_server(runtime, port).await;
 }
 
 #[tokio::test]
@@ -133,5 +133,5 @@ async fn test_post_index_query() {
         .unwrap();
 
     assert_eq!(res.status(), 200);
-    stop_server(runtime).await;
+    stop_server(runtime, port).await;
 }


### PR DESCRIPTION
### Purpose

This PR will replace OasysDB HashMap key-value store that doesn't persist with `sled` embeddable database that persist. There might be a trade-off in the performance but I haven't test anything related with this yet.

Sled is an embeddable key-value database that is ACID compliant making it a suitable option to persist data of OasysDB. For more information about Sled, check out their [GitHub repo](https://github.com/spacejam/sled) or [Rust docs](https://docs.rs/sled/latest/sled/index.html).

### Approach

Although it's not the best option to add more dependencies, Sled is a pretty decent option that we have to achieve great persistance with minimal time investment.

I have tried creating a append-only log from scratch using commitlog crate but I encounter a roadblock and unable to resolve it even after reading the docs.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

This PR introduce a new functionality in the test suite, creating different data storage when running the test and deleting them once the test is run. This is needed because the main data storage `/data` can't be shared across different server task runner.

Beyond that, to test the persistance, I test it manually using my HTTP client to create a value, restart the server, and fetch the same value which result in the same value being returned.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
