### PR TITLE
feat: graph build allow data filter

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,21 +4,17 @@ First of all, thank you for considering contributing to OasysDB! We welcome cont
 
 ## Code of Conduct
 
-We are committed to creating a welcoming community. Any participant in our project is expected to act respectfully and to follow the [Code of Conduct](/docs/code_of_conduct.md).
+We are committed to building an inclusive and welcoming community. We believe that it will lead to a more successful project and a better experience for everyone involved. To achieve that, any participant in our project is expected to act respectfully and to follow the [Code of Conduct](/docs/code_of_conduct.md).
 
 ## Have questions or suggestions?
 
 [![Discord](https://img.shields.io/discord/1182432298382131200?logo=discord&logoColor=%23ffffff&label=Discord&labelColor=%235865F2&style=for-the-badge)](https://discord.gg/bDhQrkqNP4)
 
-There is no such thing as a stupid question. If you have a question, chances are someone else does too. We encourage you to ask questions on our [Discord](https://discord.gg/bDhQrkqNP4) server.
-
-Alternatively, you can open a discussion on [GitHub Discussions](https://github.com/oasysai/oasysdb/discussions) with your question or suggestion.
+There is no such thing as a stupid question. If you have a question, chances are someone else does too. We encourage you to ask questions on our [Discord](https://discord.gg/bDhQrkqNP4) server. Alternatively, you can open a discussion on [GitHub Discussions](https://github.com/oasysai/oasysdb/discussions) with your question or suggestion.
 
 ## Encounter a bug? Have a feature request?
 
-If you encounter a bug or have a feature request, please open an issue on [GitHub Issues](https://github.com/oasysai/oasysdb/issues).
-
-Please include as much information as possible in your issue. This includes:
+If you encounter a bug or have a feature request, please open an issue on [GitHub Issues](https://github.com/oasysai/oasysdb/issues). Please include as much information as possible in your issue. This includes:
 
 - A description of the bug or feature request.
 - If it's a bug, steps to reproduce the bug. If it's a feature request, include the use case and expected behavior of the feature.
@@ -26,11 +22,13 @@ Please include as much information as possible in your issue. This includes:
 
 ## Want to contribute code?
 
+**TLDR: Check and open an issue first before forking the repository and submitting a pull request.**
+
 Before you start working on a pull request, we encourage you to check out the existing issues and pull requests to make sure that someone else isn't already working on the same thing. After all, we don't want you to waste your time!
 
 We try to prioritize features and bug fixes that are requested by the community. If you want to work on a feature or bug fix that isn't already in the issue tracker, please open an issue first to discuss it with the community.
 
-For features, we try to prioritize features that are backed by real-world use cases. If you have a use case for a feature, please include it in the issue.
+For features, we try to prioritize features that are backed by real-world use cases. If you have a use case for a feature, please include it in the issue. We'd love to hear about it!
 
 # Getting started
 
@@ -44,9 +42,7 @@ To run OasysDB locally, clone the repository and add `.env` file to the root of 
 cargo run
 ```
 
-By default, this will start OasysDB on port 3141. You can change this by setting the `OASYSDB_PORT` environment variable.
-
-Then, you can use any HTTP client to interact with OasysDB like curl or Postman.
+By default, this will start OasysDB on port 3141. If for some reason you need to change the port, you can do so by setting the `ROCKET_PORT` environment variable. Then, you can use any HTTP client to interact with OasysDB like curl or Postman.
 
 ## Style guide
 
@@ -64,7 +60,7 @@ As an alternative to using Rust, you can use Docker to run OasysDB locally. Firs
 docker build -t oasysdb .
 ```
 
-This will build the Docker image for OasysDB which you can then run locally. If you need guidance on how to run OasysDB locally, please refer to this [documentation](/readme.md#with-docker).
+This will build the Docker image for OasysDB which you can then run locally. If you need guidance on how to run OasysDB locally, please refer to this [documentation](/readme.md#getting-started).
 
 ## Submitting a pull request
 
@@ -83,7 +79,7 @@ feat: add support ...
 fix: fix issue ...
 ```
 
-This is similar to the format used by [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+This is similar to the format used in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ## Conclusion
 

--- a/readme.md
+++ b/readme.md
@@ -101,9 +101,7 @@ Optional request body:
 
 This endpoint creates a graph. The graph is used to query for nearest neighbors. If there is no data provided, the server will create a default graph with the name `default` and the default `ef_construction` and `ef_search` values of 100 for both.
 
-The filter object is used to filter the values that are added to the graph. For example, if you only want to add values with the `type` key set to `fact`, you can use the filter object above.
-
-The filter operation is similar to the `OR` operation. This means if you have multiple filters, the server will add values that match any of the filters.
+The filter object is used to filter the values that are added to the graph. For example, if you only want to add values with the `type` data key set to `fact`, you can use the filter object above. The filter operation is similar to the `AND` operation. This means if you have multiple filters, the server will only add values that match all of filters.
 
 ### Query the graph
 

--- a/readme.md
+++ b/readme.md
@@ -56,13 +56,9 @@ You can replace `localhost` with the IP address of the server if you are running
 
 ## Quickstart
 
-To put it simply, these are the primary steps to get started with OasysDB:
+To put it simply, these are the primary steps to get started with OasysDB: Setting values, creating a graph, and querying the graph.
 
-1. Set a value.
-2. Create a graph.
-3. Query the graph.
-
-### Set a value
+### Setting a value
 
 ```
 POST /values/<key>
@@ -80,7 +76,7 @@ POST /values/<key>
 
 This endpoint sets a value for a given key. The value is an embedding and an optional data object. The embedding is a list of floating-point numbers. The data object is a JSON object of string keys and values.
 
-### Create a graph
+### Creating a graph
 
 ```
 POST /graphs
@@ -101,9 +97,11 @@ Optional request body:
 
 This endpoint creates a graph. The graph is used to query for nearest neighbors. If there is no data provided, the server will create a default graph with the name `default` and the default `ef_construction` and `ef_search` values of 100 for both.
 
-The filter object is used to filter the values that are added to the graph. For example, if you only want to add values with the `type` data key set to `fact`, you can use the filter object above. The filter operation is similar to the `AND` operation. This means if you have multiple filters, the server will only add values that match all of filters.
+The filter object is used to filter the values that are added to the graph. For example, if you only want to add values with the `type` data key set to `fact`, you can use the filter object above.
 
-### Query the graph
+The filter operation is similar to the `AND` operation. This means if you have multiple filters, the server will only add values that match all of filters. Without a filter, the server will add all values to build the graph.
+
+### Querying the graph
 
 ```
 POST /graphs/<name>/query
@@ -126,7 +124,9 @@ This endpoint queries the graph for the nearest neighbors of the given embedding
 
 ### More resources
 
-For more information, please see the [OasysDB documentation](https://www.oasysai.com/docs).
+These are the primary steps to get started with OasysDB. If you want to go deeper, we have more resources available on our documentation site: [OasysDB Docs](https://www.oasysai.com/docs).
+
+If you have any questions, you can join our [Discord](https://discord.gg/bDhQrkqNP4) and ask us there or open a discussion on GitHub for your question. We'll be happy to help.
 
 ## Disclaimer
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ OasysDB is a vector database that can be used to store and query high-dimensiona
 
 - **HNSW indexing**: OasysDB uses the HNSW algorithm to build graphs to index embeddings. This allows for fast and accurate nearest neighbor search.
 
-- **Multi-graph support (WIP)**: OasysDB supports multiple HNSW graphs. This allows you to version and customize your graphs to suit different use cases. For example, optimizing speed for a specific query type or optimizing accuracy for a specific dataset.
+- **Multi-graph support**: OasysDB supports multiple HNSW graphs. This allows you to version and customize your graphs to suit different use cases. For example, optimizing speed for a specific query type or optimizing accuracy for a specific dataset.
 
 ## Getting Started
 
@@ -70,8 +70,11 @@ POST /values/<key>
 
 ```json
 {
-  "embedding": [1.0, 2.0, 3.0],
-  "data": { "text": "OasysDB is awesome!" }
+  "embedding": [0.1, 0.2, 0.3],
+  "data": {
+    "type": "fact",
+    "text": "OasysDB is awesome!"
+  }
 }
 ```
 
@@ -89,11 +92,18 @@ Optional request body:
 {
   "name": "my-graph",
   "ef_construction": 10,
-  "ef_search": 10
+  "ef_search": 10,
+  "filter": {
+    "type": "fact"
+  }
 }
 ```
 
 This endpoint creates a graph. The graph is used to query for nearest neighbors. If there is no data provided, the server will create a default graph with the name `default` and the default `ef_construction` and `ef_search` values of 100 for both.
+
+The filter object is used to filter the values that are added to the graph. For example, if you only want to add values with the `type` key set to `fact`, you can use the filter object above.
+
+The filter operation is similar to the `OR` operation. This means if you have multiple filters, the server will add values that match any of the filters.
 
 ### Query the graph
 
@@ -114,7 +124,7 @@ This endpoint queries the graph for the nearest neighbors of the given embedding
 
 - All embedding dimensions must match the dimension configured in the server using the `OASYSDB_DIMENSION` environment variable.
 - Requests to `/graphs` and `/values` endpoints must include the `x-oasysdb-token` header with the value of the `OASYSDB_TOKEN` environment variable.
-- Currently, OasysDB doesn't support auto graph building. This means whenever you add or remove a value, you need to rebuild the graph.
+- OasysDB doesn't support automatic graph building due to its versioning and filtering nature. This means whenever you add or remove a value, you need to rebuild the graph.
 
 ### More resources
 

--- a/src/api/graphs.rs
+++ b/src/api/graphs.rs
@@ -12,11 +12,17 @@ pub struct CreateGraphBody {
     pub name: Option<String>,
     pub ef_construction: Option<usize>,
     pub ef_search: Option<usize>,
+    pub filter: Option<Data>,
 }
 
 impl CreateGraphBody {
     fn default() -> Self {
-        CreateGraphBody { name: None, ef_construction: None, ef_search: None }
+        CreateGraphBody {
+            name: None,
+            ef_construction: None,
+            ef_search: None,
+            filter: None,
+        }
     }
 }
 
@@ -35,7 +41,8 @@ pub fn create_graph(
         let name = data.name.unwrap_or("default".into());
         let ef_construction = data.ef_construction.unwrap_or(100);
         let ef_search = data.ef_search.unwrap_or(100);
-        GraphConfig { name, ef_construction, ef_search }
+        let filter = data.filter;
+        GraphConfig { name, ef_construction, ef_search, filter }
     };
 
     match db.create_graph(config) {

--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -248,14 +248,14 @@ impl instant_distance::Point for Value {
 }
 
 /// Checks if the given data matches the given filter. Iterates over the
-/// filter to check if any of the data matches. If it does, return `true`.
-/// If it doesn't, return `false`.
+/// filter to check if any of the data matches. Only if the value matches
+/// over all of the filter, it will return true.
 fn filter_data_match(data: &Data, filter: &Data) -> bool {
     for (key, value) in filter {
-        if data.get(key).unwrap() == value {
-            return true;
+        if data.get(key).unwrap() != value {
+            return false;
         }
     }
 
-    false
+    true
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -48,12 +48,15 @@ fn create_test_client(id: &str) -> Client {
         db.set_value(&i.to_string(), value).unwrap();
     }
 
-    // Build initial graph for testing.
-    let _ = {
-        let name = "default".to_string();
-        let config = GraphConfig { name, ef_construction: 10, ef_search: 10 };
-        db.create_graph(config)
+    let config = GraphConfig {
+        name: "default".to_string(),
+        ef_construction: 10,
+        ef_search: 10,
+        filter: None,
     };
+
+    // Build initial graph for testing.
+    let _ = db.create_graph(config);
 
     let rocket = create_server(db);
     Client::tracked(rocket).unwrap()

--- a/src/tests/test_graphs.rs
+++ b/src/tests/test_graphs.rs
@@ -8,7 +8,13 @@ fn test_create_graph() {
     let name = Some("all".to_string());
     let ef_construction = Some(10);
     let ef_search = Some(10);
-    let data = CreateGraphBody { name, ef_construction, ef_search };
+
+    let data = CreateGraphBody {
+        name,
+        ef_construction,
+        ef_search,
+        ..Default::default()
+    };
 
     // Send request to create graph.
     let header = get_auth_header();


### PR DESCRIPTION
### Purpose

This PR introduce a feature that allows users to filter the data while building a graph. This allows building a graph with a specific set of values. This is useful to support multiple custom graph in the same database.

For example, if we have data with type image or text, we can have one graph for image type only and another one for text type only.

### Approach

We simply iterate over the filters which now is included in the data to build the graph, the graph configuration data. Then, we match if the values that we want to use to build a graph match any of the filter. If it is, we include it in the values used to build graph.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I have tested the functionality locally with an HTTP client to create multiple values with 2 different IDs and used this functionality to create 2 different graph for each ID.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
