### PR TITLE
feat: add reset endpoints

### DIFF
--- a/src/api/graphs.rs
+++ b/src/api/graphs.rs
@@ -1,3 +1,5 @@
+// Endpoints will be prefixed with /graphs.
+
 use super::*;
 use rocket::http::Status;
 use rocket::serde::json::Json;
@@ -86,6 +88,14 @@ pub fn query_graph(
 
     match db.query_graph(name, data.embedding, k) {
         Ok(data) => (Status::Ok, Response::from(data)),
+        Err(message) => (Status::BadRequest, Response::error(message)),
+    }
+}
+
+#[delete("/")]
+pub fn reset_graphs(db: &State<Database>, _auth: Auth) -> (Status, Response) {
+    match db.reset_graphs() {
+        Ok(_) => (Status::Ok, Response::empty()),
         Err(message) => (Status::BadRequest, Response::error(message)),
     }
 }

--- a/src/api/values.rs
+++ b/src/api/values.rs
@@ -1,3 +1,5 @@
+// Endpoints will be prefixed with /values.
+
 use super::*;
 use rocket::http::Status;
 use rocket::serde::json::Json;
@@ -35,6 +37,14 @@ pub fn delete_value(
     _auth: Auth,
 ) -> (Status, Response) {
     match db.delete_value(key) {
+        Ok(_) => (Status::Ok, Response::empty()),
+        Err(message) => (Status::BadRequest, Response::error(message)),
+    }
+}
+
+#[delete("/")]
+pub fn reset_values(db: &State<Database>, _auth: Auth) -> (Status, Response) {
+    match db.reset_values() {
         Ok(_) => (Status::Ok, Response::empty()),
         Err(message) => (Status::BadRequest, Response::error(message)),
     }

--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -119,6 +119,13 @@ impl Database {
         }
     }
 
+    pub fn reset_values(&self) -> Result<(), Error> {
+        match self.value_db.clear() {
+            Ok(_) => Ok(()),
+            Err(_) => Err("Failed to reset values."),
+        }
+    }
+
     // Graph methods.
 
     /// Creates a graph with the given configuration. This will create a
@@ -228,6 +235,13 @@ impl Database {
 
         data.truncate(k);
         Ok(data)
+    }
+
+    pub fn reset_graphs(&self) -> Result<(), Error> {
+        match self.graph_db.clear() {
+            Ok(_) => Ok(()),
+            Err(_) => Err("Failed to reset graphs."),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ pub fn get_env(key: &str) -> String {
 /// [Rocket documentation](https://rocket.rs/v0.5/guide/).
 pub fn create_server(db: Database) -> Rocket<Build> {
     let utils = routes![get_status, get_version];
-    let values = routes![set_value, get_value, delete_value];
-    let graphs = routes![create_graph, delete_graph, query_graph];
+    let values = routes![set_value, get_value, delete_value, reset_values];
+    let graphs = routes![create_graph, delete_graph, query_graph, reset_graphs];
     rocket::build()
         .manage(db)
         .mount("/", utils)

--- a/src/tests/test_graphs.rs
+++ b/src/tests/test_graphs.rs
@@ -52,3 +52,11 @@ fn test_delete_graph() {
     let response = client.delete("/graphs/default").header(header).dispatch();
     assert_eq!(response.status(), Status::Ok);
 }
+
+#[test]
+fn test_reset_graphs() {
+    let client = create_test_client("test_reset_graphs");
+    let header = get_auth_header();
+    let response = client.delete("/graphs").header(header).dispatch();
+    assert_eq!(response.status(), Status::Ok);
+}

--- a/src/tests/test_values.rs
+++ b/src/tests/test_values.rs
@@ -35,3 +35,11 @@ fn test_delete_value() {
     let response = client.delete("/values/0").header(header).dispatch();
     assert_eq!(response.status(), Status::Ok);
 }
+
+#[test]
+fn test_reset_values() {
+    let client = create_test_client("test_reset_values");
+    let header = get_auth_header();
+    let response = client.delete("/values").header(header).dispatch();
+    assert_eq!(response.status(), Status::Ok);
+}


### PR DESCRIPTION
### Purpose

The purpose of this PR is to add endpoints to reset the database as described in issue #13. There are 2 endpoints added, one to reset the values database and the other is to reset the graphs database.

### Approach

I simply add 2 new database method which the underlying storage engine, Sled, already provided by default. Then, I add 2 new endpoints respectively to reset the graphs and the values.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I added 2 new unit tests to test the newly added functionality.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
