### PR TITLE
fix: make metadata public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "oasysdb"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oasysdb"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "readme.md"

--- a/examples/extract-metadata.rs
+++ b/examples/extract-metadata.rs
@@ -1,0 +1,17 @@
+use oasysdb::prelude::*;
+
+fn main() {
+    // Inserting a metadata value into a record.
+    let data: &str = "This is an example.";
+    let vector = Vector::random(128);
+    let record = Record::new(&vector, &data.into());
+
+    // Extracting the metadata value.
+    let metadata = record.data.clone();
+    let data = match metadata {
+        Metadata::Text(value) => value,
+        _ => panic!("Data is not a text."),
+    };
+
+    println!("{}", data);
+}

--- a/readme.md
+++ b/readme.md
@@ -34,9 +34,7 @@ cargo add oasysdb
 After that, you can use the code snippet below as a reference to get started with OasysDB. In short, use `Collection` to store your vector records or search similar vector and use `Database` to persist a vector collection to the disk.
 
 ```rust
-use oasysdb::collection::*;
-use oasysdb::database::Database;
-use oasysdb::vector::*;
+use oasysdb::prelude::*;
 
 fn main() {
     // Vector dimension must be uniform.
@@ -54,6 +52,30 @@ fn main() {
     // Search for the nearest neighbors.
     let result = collection.search(&query, 5).unwrap();
     println!("Nearest ID: {}", result[0].id);
+}
+```
+
+## Dealing with Metadata
+
+In OasysDB, you can store additional metadata for each vector which is useful to associate the vectors with other data. The code snippet below shows how to insert the `Metadata` to the `Record` or extract it.
+
+```rust
+use oasysdb::prelude::*;
+
+fn main() {
+    // Inserting a metadata value into a record.
+    let data: &str = "This is an example.";
+    let vector = Vector::random(128);
+    let record = Record::new(&vector, &data.into());
+
+    // Extracting the metadata value.
+    let metadata = record.data.clone();
+    let data = match metadata {
+        Metadata::Text(value) => value,
+        _ => panic!("Data is not a text."),
+    };
+
+    println!("{}", data);
 }
 ```
 

--- a/src/func/mod.rs
+++ b/src/func/mod.rs
@@ -2,11 +2,12 @@
 pub mod collection;
 /// Error types for the database.
 pub mod err;
+/// Types for the metadata.
+pub mod metadata;
 /// Types for the vectors.
 pub mod vector;
 
 // Internal modules.
-mod metadata;
 mod utils;
 
 use metadata::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,10 @@ mod tests;
 mod db;
 mod func;
 
+/// Convenience re-exports for the public APIs.
+pub mod prelude;
+
 pub use db::database;
 pub use func::collection;
+pub use func::metadata;
 pub use func::vector;

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -1,0 +1,4 @@
+pub use crate::database::*;
+pub use crate::func::collection::*;
+pub use crate::func::metadata::*;
+pub use crate::func::vector::*;


### PR DESCRIPTION
### Purpose

This PR solves an issue where user is unable to access the value inside of the `Metadata` since it's not a public module. With this use case, users can access the value inside the `Metadata` using the `match` statement.

### Approach

This PR makes `Metadata` public and add a `prelude` module that allows users to import OasysDB structs, enums, and types using `use oasysdb::prelude::*;` instead of importing modules separately.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

No additional functionality needed beside adding the `prelude` imports which is tested via `cargo test`.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
