### PR TITLE
fix: implement debug trait for collection & config

### DIFF
--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// The collection HNSW index configuration.
-#[derive(Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct Config {
     /// Nodes to consider during construction.
     pub ef_construction: usize,
@@ -107,7 +107,7 @@ impl<'a> IndexConstruction<'a> {
 }
 
 /// The collection of vector records with HNSW indexing.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Collection {
     /// The collection configuration object.
     pub config: Config,


### PR DESCRIPTION
### Purpose

This PR solves an issue where user use `typed-builder` , the `Collection` class do not implement `Debug`


### Approach

This PR makes `Collection` and `Config` implement `Debug`


### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

How did you test this PR? Please provide a description of the tests that you ran to verify your changes.

How should the reviewer test this PR? If applicable, have you added tests to cover your changes?

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.