### PR TITLE
ci: add pytest gh action

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -59,7 +59,9 @@ jobs:
 
       - name: Install requirements
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
+          python -m venv env
+          source env/bin/activate
           pip install -r requirements.txt
 
       - name: Build development wheels

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -61,8 +61,6 @@ jobs:
         run: |
           pip install --upgrade pip
           python -m venv .venv
-          source .venv/bin/activate
-          pip install -r requirements.txt
 
       - name: Build development wheels
         uses: PyO3/maturin-action@v1
@@ -71,4 +69,7 @@ jobs:
           sccache: "true"
 
       - name: Run tests
-        run: python -m pytest
+        run: |
+          source .venv/bin/activate
+          pip install -r requirements.txt
+          python -m pytest

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -30,7 +30,7 @@ jobs:
         run: cargo clippy -- -D warnings
 
   run-rust-tests:
-    name: Run all Rust tests
+    name: Run Rust tests
     needs: clippy-lint
     runs-on: ubuntu-latest
     steps:
@@ -44,13 +44,9 @@ jobs:
         run: cargo test
 
   run-python-tests:
-    name: Build wheels and run Python tests
+    name: Run Python tests
     needs: run-rust-tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
-        python: ["3.9", "3.10", "3.11"]
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -58,7 +54,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.10
           cache: "pip"
 
       - name: Install requirements
@@ -66,19 +62,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Build wheels
+      - name: Build development wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          command: develop
           sccache: "true"
-          manylinux: auto
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: dist
 
       - name: Run tests
         run: pytest

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -60,12 +60,14 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
+          python -m venv .venv
+          source .venv/bin/activate
           pip install -r requirements.txt
 
       - name: Build development wheels
         uses: PyO3/maturin-action@v1
         with:
-          command: build
+          command: develop
           sccache: "true"
 
       - name: Run tests

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -3,7 +3,8 @@ name: Quality check and testing
 # Summary of the workflow
 # For every push to the main branch or any pull request:
 # 1. Run cargo clippy: Check linting to improve code quality.
-# 2. Run cargo test: Run all tests.
+# 2. Run cargo test: Run all Rust-based tests.
+# 3. Run pytest: Build wheels and run Python tests.
 
 on:
   pull_request:
@@ -28,8 +29,8 @@ jobs:
       - name: Run cargo clippy
         run: cargo clippy -- -D warnings
 
-  run-tests:
-    name: Run all tests
+  run-rust-tests:
+    name: Run all Rust tests
     needs: clippy-lint
     runs-on: ubuntu-latest
     steps:
@@ -41,3 +42,43 @@ jobs:
 
       - name: Run cargo test
         run: cargo test
+
+  run-python-tests:
+    name: Build wheels and run Python tests
+    needs: run-rust-tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        python: ["3.9", "3.10", "3.11"]
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: "pip"
+
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter
+          sccache: "true"
+          manylinux: auto
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -71,4 +71,4 @@ jobs:
           sccache: "true"
 
       - name: Run tests
-        run: pytest
+        run: python -m pytest

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -60,14 +60,12 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade pip
-          python -m venv env
-          source env/bin/activate
           pip install -r requirements.txt
 
       - name: Build development wheels
         uses: PyO3/maturin-action@v1
         with:
-          command: develop
+          command: build
           sccache: "true"
 
       - name: Run tests

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
           cache: "pip"
 
       - name: Install requirements


### PR DESCRIPTION
### Purpose

Since we are creating a Python binding to allow OasysDB to be used from Python projects, we need a way to automate the testing process of the Python interoperability to make sure that everything is usable from both Rust and Python. So, this PR adds a new jobs to the CI to run `pytest`.

### Approach

This PR uses `PyO3/maturin-action` to build OasysDB wheels that is usable and testable. Then the CI will setup the Python environment and run `pytest` against the `py/tests` directory of the project.

### Testing

- [ ] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

This is a CI changes without any additional feature on the codebase added.

### Chore checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added comments to most of my code, particularly in hard-to-understand areas.
