### PR TITLE
feat: add list api

### DIFF
--- a/py/oasysdb/collection.pyi
+++ b/py/oasysdb/collection.pyi
@@ -1,6 +1,6 @@
 # flake8: noqa F821
 
-from typing import Any, List
+from typing import Any, List, Dict
 from oasysdb.vector import Vector
 
 
@@ -111,6 +111,11 @@ class Collection:
 
         Args:
         - id (int): Vector ID to fetch.
+        """
+
+    def list(self) -> Dict[int, Record]:
+        """Returns a dictionary of records in the collection
+        in the format of { ID: Record }.
         """
 
     def update(self, id: int, record: Record) -> None:

--- a/py/tests/test_collection.py
+++ b/py/tests/test_collection.py
@@ -146,3 +146,12 @@ def test_set_dimension():
         assert False
     except Exception as e:
         assert "invalid vector dimension" in str(e).lower()
+
+
+def test_list_records():
+    collection = create_test_collection()
+    records = collection.list()
+
+    assert len(records) == collection.len()
+    assert all(isinstance(k, int) for k in records.keys())
+    assert all(isinstance(v, Record) for v in records.values())

--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -378,6 +378,25 @@ impl Collection {
         Ok(())
     }
 
+    /// Returns vector records in the collection as a HashMap.
+    pub fn list(&self) -> Result<HashMap<usize, Record>, Error> {
+        // Early return if the collection is empty.
+        if self.vectors.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        // Map the vectors to a hashmap of records.
+        let mapper = |(id, vector): (&VectorID, &Vector)| {
+            let data = self.data[id].clone();
+            let record = Record::new(vector.clone(), data);
+            let id = id.0 as usize;
+            (id, record)
+        };
+
+        let records = self.vectors.par_iter().map(mapper).collect();
+        Ok(records)
+    }
+
     /// Returns the vector record associated with the ID.
     /// * `id`: Vector ID to retrieve.
     pub fn get(&self, id: usize) -> Result<Record, Error> {

--- a/src/tests/test_collection.rs
+++ b/src/tests/test_collection.rs
@@ -111,3 +111,14 @@ fn get() {
     assert_eq!(record.data, records[id].data);
     assert_eq!(record.vector, records[id].vector);
 }
+
+#[test]
+fn list() {
+    let records = Record::many_random(DIMENSION, LEN);
+    let collection = create_collection(records.clone());
+
+    // Get all records from the collection.
+    let list = collection.list().unwrap();
+    assert_eq!(list.len(), LEN);
+    assert_eq!(list.len(), collection.len());
+}


### PR DESCRIPTION
### Purpose

This API introduces a new API to the `Collection` as defined below. This API will return all of the records contain in the collection in the form of a HashMap of the Vector ID as a primitive type of `usize` and `Record` which contains vector and metadata.

```rs
pub fn list(&self) -> Result<HashMap<usize, Record>, Error> {...}
```

### Approach

Currently, this adds a very barebone approach of doing this without other utility functionality like pagination or return limit.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I have added a test for each `cargo test` and `pytest` to test this implementation.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
