### PR TITLE
chore: add docs and refactor

### DIFF
--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -7,8 +7,12 @@ fn main() {
     // Replace with your own data.
     let records = Record::many_random(dimension, 100);
 
+    let mut config = Config::default();
+
+    // Optionally set the distance function. Default to Euclidean.
+    config.distance = Distance::Cosine;
+
     // Create a vector collection.
-    let config = Config::default();
     let collection = Collection::build(&config, &records).unwrap();
 
     // Optionally save the collection to persist it.

--- a/py/example.py
+++ b/py/example.py
@@ -7,17 +7,20 @@ if __name__ == "__main__":
     # Open the database.
     db = Database("data/example")
 
+    # Replace with your own records.
+    records = Record.many_random(dimension=128, len=100)
+
     # Create a vector collection.
     config = Config.create_default()
-    records = Record.many_random(dimension=128, len=100)
     collection = Collection.from_records(config, records)
 
     # Optionally, persist the collection to the database.
     db.save_collection("my_collection", collection)
 
-    # Search for the nearest neighbors.
     # Replace with your own query.
     query = Vector.random(128)
+
+    # Search for the nearest neighbors.
     result = collection.search(query, n=5)
 
     # Print the result.

--- a/py/oasysdb/collection.pyi
+++ b/py/oasysdb/collection.pyi
@@ -11,6 +11,7 @@ class Config:
     - ef_construction: Nodes to consider during index construction.
     - ef_search: Nodes to consider during the search.
     - ml: Layer multiplier of the HNSW index.
+    - distance: Distance metric function.
     """
 
     ef_construction: int
@@ -34,7 +35,7 @@ class Config:
         - ef_construction: 40
         - ef_search: 15
         - ml: 0.3
-        - distance: 'euclidean'
+        - distance: euclidean
         """
 
 
@@ -80,6 +81,7 @@ class Collection:
     """The collection of vectors and their metadata."""
 
     config: Config
+    dimension: int
 
     def __init__(self, config: Config) -> None: ...
 
@@ -144,17 +146,6 @@ class Collection:
         Args:
         - vector: Vector to search.
         - n: Number of neighbors to return.
-        """
-
-    def dimension(self) -> int:
-        """Returns the configured vector dimension in the collection."""
-
-    def set_dimension(self, dimension: int) -> None:
-        """Sets the vector dimension of the collection.
-        The collection must be empty to do this.
-
-        Args:
-        - dimension: Vector dimension.
         """
 
     def len(self) -> int:

--- a/py/tests/test_collection.py
+++ b/py/tests/test_collection.py
@@ -15,8 +15,15 @@ def create_test_collection() -> Collection:
 
 
 def test_create_config():
-    config = Config(ef_construction=40, ef_search=15, ml=0.3, distance='euclidean')
     default = Config.create_default()
+
+    # Create config based on the default.
+    config = Config(
+        ef_construction=40,
+        ef_search=15,
+        ml=0.3,
+        distance="euclidean"
+    )
 
     assert config.ef_construction == default.ef_construction
     assert config.ef_search == default.ef_search
@@ -135,8 +142,7 @@ def test_set_dimension():
     collection = Collection(config=config)
 
     # Set the collection dimension to 100.
-    collection.set_dimension(100)
-    assert collection.dimension() == 100
+    collection.dimension = 100
 
     # When inserting a record with a different dimension,
     # the collection should raise an exception.

--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,8 @@ if __name__ == "__main__":
     print("Nearest neighbors ID: {}".format(result[0].id))
 ```
 
+If you want to learn more about using OasysDB for real-world applications, you can check out the this Google Colab notebook which demonstrates how to use OasysDB to build a simple image similarity search engine: [Image Search Engine with OasysDB](https://colab.research.google.com/drive/15_1hH7jGKzMeQ6IfnScjsc-iJRL5XyL7?usp=sharing)
+
 # 🎯 Benchmarks
 
 OasysDB uses a built-in benchmarking suite using Rust's [Criterion](https://docs.rs/criterion) crate which we use to measure the performance of the vector database.

--- a/readme.md
+++ b/readme.md
@@ -43,8 +43,12 @@ fn main() {
     // Replace with your own data.
     let records = Record::many_random(dimension, 100);
 
+    let mut config = Config::default();
+
+    // Optionally set the distance function. Default to Euclidean.
+    config.distance = Distance::Cosine;
+
     // Create a vector collection.
-    let config = Config::default();
     let collection = Collection::build(&config, &records).unwrap();
 
     // Optionally save the collection to persist it.
@@ -100,17 +104,20 @@ if __name__ == "__main__":
     # Open the database.
     db = Database("data/example")
 
+    # Replace with your own records.
+    records = Record.many_random(dimension=128, len=100)
+
     # Create a vector collection.
     config = Config.create_default()
-    records = Record.many_random(dimension=128, len=100)
     collection = Collection.from_records(config, records)
 
     # Optionally, persist the collection to the database.
     db.save_collection("my_collection", collection)
 
-    # Search for the nearest neighbors.
     # Replace with your own query.
     query = Vector.random(128)
+
+    # Search for the nearest neighbors.
     result = collection.search(query, n=5)
 
     # Print the result.

--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -594,6 +594,12 @@ impl Record {
         Self::new(&vector, &data)
     }
 
+    #[setter]
+    fn set_data(&mut self, data: &PyAny) -> Result<(), Error> {
+        self.data = Metadata::from(data);
+        Ok(())
+    }
+
     /// Generates a random record for testing.
     /// * `dimension`: Vector dimension.
     #[staticmethod]

--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -1,5 +1,3 @@
-use self::distance::Distance;
-
 use super::*;
 
 /// The collection HNSW index configuration.
@@ -15,9 +13,9 @@ pub struct Config {
     /// Layer multiplier. The optimal value is `1/ln(M)`.
     #[pyo3(get, set)]
     pub ml: f32,
-    /// Distance Calculation. Supported formula `euclidean`,`cosine`,`dot`
-    #[pyo3(get, set)]
-    pub distance: String,
+    /// Distance calculation function.
+    #[pyo3(get)]
+    pub distance: Distance,
 }
 
 // Any modifications to this methods should be reflected in:
@@ -33,9 +31,16 @@ impl Config {
         ml: f32,
         distance: &str,
     ) -> Result<Self, Error> {
-        Distance::from(distance)?;
+        let distance = Distance::from(distance)?;
+        Ok(Self { ef_construction, ef_search, ml, distance })
+    }
 
-        Ok(Self { ef_construction, ef_search, ml, distance: distance.into() })
+    /// Sets the distance calculation function.
+    /// * `distance`: Distance function, e.g. euclidean or dot.
+    #[setter]
+    pub fn set_distance(&mut self, distance: &str) -> Result<(), Error> {
+        self.distance = Distance::from(distance)?;
+        Ok(())
     }
 
     #[staticmethod]
@@ -53,12 +58,13 @@ impl Default for Config {
     /// * `ef_construction`: 40
     /// * `ef_search`: 15
     /// * `ml`: 0.3
+    /// * `distance`: euclidean
     fn default() -> Self {
         Self {
             ef_construction: 40,
             ef_search: 15,
             ml: 0.3,
-            distance: "euclidean".into(),
+            distance: Distance::Euclidean,
         }
     }
 }
@@ -304,8 +310,7 @@ impl Collection {
         // Calculate the distance between the query and each record.
         // Then, create a search result for each record.
         for (id, vec) in self.vectors.iter() {
-            let distance =
-                Distance::from(&self.config.distance)?.calculate(vector, vec);
+            let distance = self.config.distance.calculate(vector, vec);
             let data = self.data[id].clone();
             let res = SearchResult { id: id.0, distance, data };
             nearest.push(res);
@@ -318,12 +323,14 @@ impl Collection {
     }
 
     /// Returns the configured vector dimension of the collection.
+    #[getter]
     pub fn dimension(&self) -> usize {
         self.dimension
     }
 
     /// Sets the vector dimension of the collection.
     /// * `dimension`: New vector dimension.
+    #[setter]
     pub fn set_dimension(&mut self, dimension: usize) -> Result<(), Error> {
         // This can only be set if the collection is empty.
         if !self.vectors.is_empty() {

--- a/src/func/distance.rs
+++ b/src/func/distance.rs
@@ -1,85 +1,74 @@
-use serde::{Deserialize, Serialize};
+use super::*;
 
-use super::{err::Error, Vector};
-
+/// The distance function used for similarity calculations.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub enum Distance {
+    /// Dot product function.
     Dot,
+    /// Euclidean distance function.
     Euclidean,
+    /// Cosine similarity function.
     Cosine,
 }
 
 impl Distance {
+    /// Creates a new distance function from a string.
+    /// Available options:
+    /// * `dot`: Dot product function.
+    /// * `euclidean`: Euclidean distance function.
+    /// * `cosine`: Cosine similarity function.
     pub fn from(distance: &str) -> Result<Self, Error> {
         match distance {
             "dot" => Ok(Distance::Dot),
             "euclidean" => Ok(Distance::Euclidean),
             "cosine" => Ok(Distance::Cosine),
-            _ => Err("Distance not supported".into()),
+            _ => Err("Distance function not supported.".into()),
         }
     }
 
+    /// Calculates the distance between two vectors.
     pub fn calculate(&self, a: &Vector, b: &Vector) -> f32 {
         assert_eq!(a.0.len(), b.0.len());
-
         match self {
-            Distance::Dot => calculate_dot(a, b),
-            Distance::Euclidean => calculate_euclidean(a, b),
-            Distance::Cosine => calculate_cosine(a, b),
+            Distance::Dot => Distance::dot(a, b),
+            Distance::Euclidean => Distance::euclidean(a, b),
+            Distance::Cosine => Distance::cosine(a, b),
         }
+    }
+
+    // List additional distance functions below.
+
+    fn dot(a: &Vector, b: &Vector) -> f32 {
+        let zip = a.0.iter().zip(b.0.iter());
+        zip.map(|(x, y)| x * y).sum()
+    }
+
+    fn cosine(a: &Vector, b: &Vector) -> f32 {
+        let dot = Self::dot(a, b);
+        let ma = a.0.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
+        let mb = b.0.iter().map(|y| y.powi(2)).sum::<f32>().sqrt();
+        dot / (ma * mb)
+    }
+
+    fn euclidean(a: &Vector, b: &Vector) -> f32 {
+        let zip = a.0.iter().zip(b.0.iter());
+        zip.map(|(a, b)| (a - b).powi(2)).sum::<f32>().sqrt()
     }
 }
 
-fn calculate_dot(a: &Vector, b: &Vector) -> f32 {
-    a.0.iter().zip(b.0.iter()).map(|(x, y)| x * y).sum::<f32>()
-}
-fn calculate_cosine(a: &Vector, b: &Vector) -> f32 {
-    let dot_product: f32 = a.0.iter().zip(b.0.iter()).map(|(x, y)| x * y).sum();
-    let magnitude_a: f32 = a.0.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
-    let magnitude_b: f32 = b.0.iter().map(|y| y.powi(2)).sum::<f32>().sqrt();
-
-    dot_product / (magnitude_a * magnitude_b)
-}
-fn calculate_euclidean(a: &Vector, b: &Vector) -> f32 {
-    a.0.iter().zip(b.0.iter()).map(|(a, b)| (a - b).powi(2)).sum::<f32>().sqrt()
+impl From<&PyAny> for Distance {
+    fn from(distance: &PyAny) -> Self {
+        let distance = distance.str().unwrap().to_string();
+        Distance::from(&distance).unwrap()
+    }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn distance_calcultation() {
-        let v = Vector::from(vec![1.0, 3.0, 5.0, 7.0]);
-        let n = Vector::from(vec![11.0, 13.0, 17.0, 19.0]);
-        let dot_product: f32 =
-            v.0.iter().zip(n.0.iter()).map(|(vi, ni)| vi * ni).sum();
-        let euclidean_distance: f32 =
-            v.0.iter()
-                .zip(n.0.iter())
-                .map(|(vi, ni)| (vi - ni).powi(2))
-                .sum::<f32>()
-                .sqrt();
-        let magnitude_v: f32 =
-            v.0.iter().map(|vi| vi.powi(2)).sum::<f32>().sqrt();
-        let magnitude_n: f32 =
-            n.0.iter().map(|ni| ni.powi(2)).sum::<f32>().sqrt();
-        let cosine_similarity: f32 = dot_product / (magnitude_v * magnitude_n);
-
-        let test_cases: Vec<(String, f32)> = vec![
-            ("dot".into(), dot_product),
-            ("euclidean".into(), euclidean_distance),
-            ("cosine".into(), cosine_similarity),
-        ];
-
-        for (distance, right) in test_cases {
-            let dist_fun = Distance::from(&distance).unwrap();
-            let left = dist_fun.calculate(&v, &n);
-            assert_eq!(
-                left, right,
-                "dist: {}, left: {}, right {}",
-                distance, left, right
-            );
+impl IntoPy<Py<PyAny>> for Distance {
+    fn into_py(self, py: Python) -> Py<PyAny> {
+        match self {
+            Distance::Dot => "dot".into_py(py),
+            Distance::Euclidean => "euclidean".into_py(py),
+            Distance::Cosine => "cosine".into_py(py),
         }
     }
 }

--- a/src/func/mod.rs
+++ b/src/func/mod.rs
@@ -1,5 +1,7 @@
 /// The collection of vectors and their data.
 pub mod collection;
+/// Enum for the collection distance functions.
+pub mod distance;
 /// Error types for the database.
 pub mod err;
 /// Types for the metadata.
@@ -7,12 +9,11 @@ pub mod metadata;
 /// Types for the vectors.
 pub mod vector;
 
-pub mod distance;
-
 // Internal modules.
 mod utils;
 
 use collection::*;
+use distance::*;
 use err::*;
 use metadata::*;
 use utils::*;

--- a/src/func/utils.rs
+++ b/src/func/utils.rs
@@ -240,7 +240,7 @@ pub struct Search {
     nearest: Vec<Candidate>,
     working: Vec<Candidate>,
     discarded: Vec<Candidate>,
-    dist_func: Distance,
+    distance: Distance,
 }
 
 impl Search {
@@ -287,8 +287,8 @@ impl Search {
 
         // Create a new candidate.
         let other = &vectors[vector_id];
-        let distance =
-            OrderedFloat::from(self.dist_func.calculate(vector, other));
+        let distance = self.distance.calculate(vector, other);
+        let distance = OrderedFloat::from(distance);
         let new = Candidate { distance, vector_id: *vector_id };
 
         // Make sure the index to insert to is within the EF scope.
@@ -343,7 +343,7 @@ impl Default for Search {
             working: Vec::new(),
             discarded: Vec::new(),
             ef: 5,
-            dist_func: Distance::Euclidean,
+            distance: Distance::Euclidean,
         }
     }
 }
@@ -393,7 +393,7 @@ impl<'a> IndexConstruction<'a> {
         layers: &[Vec<UpperNode>],
     ) {
         let vector = &self.vectors[vector_id];
-        let dist_func = self.config.distance;
+        let dist = self.config.distance;
 
         let (mut search, mut insertion) = self.search_pool.pop();
         insertion.ef = self.config.ef_construction;
@@ -441,7 +441,7 @@ impl<'a> IndexConstruction<'a> {
                     Ordering::Greater
                 } else {
                     let other = &self.vectors[id];
-                    distance.cmp(&dist_func.calculate(old, other).into())
+                    distance.cmp(&dist.calculate(old, other).into())
                 }
             };
 

--- a/src/func/utils.rs
+++ b/src/func/utils.rs
@@ -393,8 +393,8 @@ impl<'a> IndexConstruction<'a> {
         layers: &[Vec<UpperNode>],
     ) {
         let vector = &self.vectors[vector_id];
-        let dist_func = Distance::from(&self.config.distance).unwrap(); // config has been validated, so we just unwrap it.
-        
+        let dist_func = self.config.distance;
+
         let (mut search, mut insertion) = self.search_pool.pop();
         insertion.ef = self.config.ef_construction;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod prelude;
 
 pub use db::database;
 pub use func::collection;
+pub use func::distance;
 pub use func::err;
 pub use func::metadata;
 pub use func::vector;

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -1,5 +1,6 @@
 pub use crate::database::*;
 pub use crate::func::collection::*;
+pub use crate::func::distance::*;
 pub use crate::func::err::*;
 pub use crate::func::metadata::*;
 pub use crate::func::vector::*;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,10 +1,8 @@
 mod test_collection;
 mod test_database;
+mod test_distance;
 
-use crate::collection::*;
-use crate::database::*;
-use crate::func::distance::Distance;
-use crate::vector::*;
+use crate::prelude::*;
 use rayon::iter::*;
 use std::collections::HashMap;
 

--- a/src/tests/test_collection.rs
+++ b/src/tests/test_collection.rs
@@ -125,14 +125,14 @@ fn list() {
 #[test]
 fn config_with_distance() {
     for dist in vec!["cosine", "dot", "euclidean"] {
-        let conf = Config::new(10, 10, 3.0, dist).unwrap();
+        Config::new(10, 10, 1.0, dist).unwrap();
     }
 }
 
 #[test]
-#[should_panic(expected = "Distance not supported")]
+#[should_panic(expected = "Distance function not supported.")]
 fn config_with_distance_panic() {
     for dist in vec!["l2", "test"] {
-        let conf = Config::new(10, 10, 3.0, dist).unwrap();
+        Config::new(10, 10, 1.0, dist).unwrap();
     }
 }

--- a/src/tests/test_collection.rs
+++ b/src/tests/test_collection.rs
@@ -124,15 +124,19 @@ fn list() {
 
 #[test]
 fn config_with_distance() {
+    let ef = 10;
+    let ml = 1.0;
     for dist in vec!["cosine", "dot", "euclidean"] {
-        Config::new(10, 10, 1.0, dist).unwrap();
+        Config::new(ef, ef, ml, dist).unwrap();
     }
 }
 
 #[test]
 #[should_panic(expected = "Distance function not supported.")]
 fn config_with_distance_panic() {
+    let ef = 10;
+    let ml = 1.0;
     for dist in vec!["l2", "test"] {
-        Config::new(10, 10, 1.0, dist).unwrap();
+        Config::new(ef, ef, ml, dist).unwrap();
     }
 }

--- a/src/tests/test_database.rs
+++ b/src/tests/test_database.rs
@@ -8,7 +8,7 @@ fn new() {
 #[test]
 fn new_with_distance() {
     let mut config = Config::default();
-    config.distance = "cosine".into();
+    config.distance = Distance::Cosine;
     let mut collection = Collection::new(&config);
     collection.insert(&Record::random(DIMENSION)).unwrap();
 }

--- a/src/tests/test_distance.rs
+++ b/src/tests/test_distance.rs
@@ -1,0 +1,15 @@
+use super::*;
+
+#[test]
+fn distance_calculation() {
+    let a = Vector::from(vec![1.0, 3.0, 5.0]);
+    let b = Vector::from(vec![2.0, 4.0, 6.0]);
+
+    let dot = Distance::Dot.calculate(&a, &b);
+    let euclidean = Distance::Euclidean.calculate(&a, &b);
+    let cosine = Distance::Cosine.calculate(&a, &b);
+
+    assert_eq!(dot, 44.0);
+    assert_eq!(euclidean, 1.7320508);
+    assert_eq!(cosine, 0.99385864);
+}


### PR DESCRIPTION
### Purpose

With the new feature that allows users to customize the distance formula used for the collection indexing, this PR adds documentation on how to configure it both from Python and Rust project. This PR also changes the implementation in a way that allows the use of `Distance` enum from Rust project while in Python, users can just set the distance using string.

This PR also adds getters and setters function to improve the usage from Python codebase.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I have modified the test suite to fit the new implementations.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
