### PR TITLE
feat: result relevancy threshold

### DIFF
--- a/py/oasysdb/collection.pyi
+++ b/py/oasysdb/collection.pyi
@@ -82,6 +82,7 @@ class Collection:
 
     config: Config
     dimension: int
+    relevancy: float
 
     def __init__(self, config: Config) -> None: ...
 

--- a/py/tests/test_collection.py
+++ b/py/tests/test_collection.py
@@ -122,6 +122,8 @@ def test_update_record():
 
 def test_search_record():
     collection = create_test_collection()
+    collection.relevancy = 4.5
+
     vector = Vector.random(dimension=DIMENSION)
     n = 10
 
@@ -135,6 +137,10 @@ def test_search_record():
     # Make sure the first result of the approximate search
     # is somewhere in the true results.
     assert results[0].id in [true.id for true in true_results]
+
+    # Check if the result distances are within the relevancy.
+    assert results[-1].distance <= collection.relevancy
+    assert true_results[-1].distance <= collection.relevancy
 
 
 def test_set_dimension():

--- a/src/func/distance.rs
+++ b/src/func/distance.rs
@@ -2,6 +2,7 @@ use super::*;
 
 /// The distance function used for similarity calculations.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Distance {
     /// Dot product function.
     Dot,

--- a/src/tests/test_collection.rs
+++ b/src/tests/test_collection.rs
@@ -80,7 +80,10 @@ fn search() {
     let len = 1000;
     let config = Config::default();
     let records = Record::many_random(DIMENSION, len);
-    let collection = Collection::build(&config, &records).unwrap();
+
+    // Build the collection with a minimum relevancy.
+    let mut collection = Collection::build(&config, &records).unwrap();
+    collection.relevancy = 4.5;
 
     // Generate a random query vector.
     let query = Vector::random(DIMENSION);
@@ -89,14 +92,18 @@ fn search() {
     let result = collection.search(&query, 5).unwrap();
     let truth = collection.true_search(&query, 10).unwrap();
 
-    // Collect the distances from the true nearest neighbors.
-    let distances: Vec<f32> = truth.par_iter().map(|i| i.distance).collect();
-
     assert_eq!(result.len(), 5);
 
     // The search is not always exact, so we check if
     // the distance is within the true distances.
+    let distances: Vec<f32> = truth.par_iter().map(|i| i.distance).collect();
     assert_eq!(distances.contains(&result[0].distance), true);
+
+    // Search results should be within the relevancy.
+    let last_result = result.last().unwrap();
+    let last_truth = truth.last().unwrap();
+    assert!(last_result.distance <= collection.relevancy);
+    assert!(last_truth.distance <= collection.relevancy);
 }
 
 #[test]


### PR DESCRIPTION
### Purpose

This PR adds a new configuration to the `Collection` struct, `relevancy` a threshold score that guards irrelevant neighbor candidates from being included into the search result. By default, it is set to -1.0 which deactivates the relevancy checks. This value can be change as needed to fine-tune the exact threshold of relevance.

To use it:

```rs
// ...
collection.relevancy = 0.3
```

### Approach

Because we have 3 `Distance` options that users can configure, I implement a check where for Euclidean distance, the distance of vector considered relevant is smaller than the relevancy score. For Dot or Cosine distance, the distance between vectors should be larger than the relevancy score.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I have modified the test of search collection to include assert statements to check the search result against the relevancy score.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
