### PR TITLE
feat: add batch insert

### DIFF
--- a/py/oasysdb/collection.pyi
+++ b/py/oasysdb/collection.pyi
@@ -86,11 +86,19 @@ class Collection:
     def __init__(self, config: Config) -> None: ...
 
     @staticmethod
-    def from_records(
-        config: Config,
-        records: List[Record],
-    ) -> Collection:
+    def from_records(config: Config, records: List[Record]) -> Collection:
         """Build a collection from the given records.
+
+        Args:
+        - config: Collection configuration.
+        - records: Records used to build the collection.
+        """
+
+    @staticmethod
+    def build(config: Config, records: List[Record]) -> Collection:
+        """Build a collection from the records.
+        This is an alias of from_records method and shared
+        the same implementation.
 
         Args:
         - config: Collection configuration.
@@ -102,6 +110,13 @@ class Collection:
 
         Args:
         - record: Record to insert.
+        """
+
+    def insert_many(self, records: List[Record]) -> List[VectorID]:
+        """Inserts multiple records into the collection.
+
+        Args:
+        - records: Records to insert.
         """
 
     def delete(self, id: VectorID) -> None:

--- a/py/tests/test_collection.py
+++ b/py/tests/test_collection.py
@@ -89,6 +89,15 @@ def test_insert_record_invalid_dimension():
     assert collection.len() == LEN
 
 
+def test_insert_many_records():
+    collection = create_test_collection()
+    records = Record.many_random(dimension=DIMENSION, len=LEN)
+    collection.insert_many(records)
+
+    assert collection.len() == 2 * LEN
+    assert all(collection.contains(VectorID(i)) for i in range(LEN, 2 * LEN))
+
+
 def test_delete_record():
     collection = create_test_collection()
 

--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -165,7 +165,7 @@ impl Collection {
 
         // This operation is last because it depends on
         // the updated vectors data.
-        self.insert_to_layers(&id);
+        self.insert_to_layers(&[id]);
 
         Ok(())
     }
@@ -187,7 +187,7 @@ impl Collection {
             return Err(Error::record_not_found());
         }
 
-        self.delete_from_layers(id);
+        self.delete_from_layers(&[*id]);
 
         // Update the collection data.
         self.vectors.remove(id);
@@ -248,12 +248,12 @@ impl Collection {
         self.validate_dimension(&record.vector)?;
 
         // Remove the old vector from the index layers.
-        self.delete_from_layers(id);
+        self.delete_from_layers(&[*id]);
 
         // Insert the updated vector and data.
         self.vectors.insert(*id, record.vector.clone());
         self.data.insert(*id, record.data.clone());
-        self.insert_to_layers(id);
+        self.insert_to_layers(&[*id]);
 
         Ok(())
     }
@@ -564,7 +564,7 @@ impl Collection {
         // Update the collection count.
         self.count += records.len();
 
-        self.insert_many_to_layers(&ids);
+        self.insert_to_layers(&ids);
         Ok(ids)
     }
 
@@ -580,55 +580,23 @@ impl Collection {
         }
     }
 
-    // Private index graph methods below.
-
-    fn create_state_base_layer(
-        &mut self,
-        add_nodes: usize,
-    ) -> Vec<RwLock<BaseNode>> {
+    /// Inserts vector IDs into the index layers.
+    fn insert_to_layers(&mut self, ids: &[VectorID]) {
         // Add new nodes to the base layer.
-        for _ in 0..add_nodes {
+        for _ in 0..ids.len() {
             self.base_layer.push(BaseNode::default());
         }
 
-        self.base_layer
+        let base_layer = self
+            .base_layer
             .par_iter()
             .map(|node| RwLock::new(*node))
-            .collect::<Vec<_>>()
-    }
+            .collect::<Vec<_>>();
 
-    fn create_state_top_layer(&mut self) -> LayerID {
-        match self.upper_layers.is_empty() {
+        let top_layer = match self.upper_layers.is_empty() {
             true => LayerID(0),
             false => LayerID(self.upper_layers.len()),
-        }
-    }
-
-    /// Inserts a vector ID into the index layers.
-    fn insert_to_layers(&mut self, id: &VectorID) {
-        let base_layer = self.create_state_base_layer(1);
-        let top_layer = self.create_state_top_layer();
-
-        let state = IndexConstruction {
-            base_layer: base_layer.as_slice(),
-            search_pool: SearchPool::new(self.vectors.len()),
-            top_layer,
-            vectors: &self.vectors,
-            config: &self.config,
         };
-
-        // Insert new vector into the contructor.
-        state.insert(id, &top_layer, &self.upper_layers);
-
-        // Update the base layer with the new state.
-        let iter = state.base_layer.into_par_iter();
-        self.base_layer = iter.map(|node| *node.read()).collect();
-    }
-
-    /// Inserts multiple vector IDs into the index layers.
-    fn insert_many_to_layers(&mut self, ids: &[VectorID]) {
-        let base_layer = self.create_state_base_layer(ids.len());
-        let top_layer = self.create_state_top_layer();
 
         // Create a new index construction state.
         let state = IndexConstruction {
@@ -649,13 +617,15 @@ impl Collection {
         self.base_layer = iter.map(|node| *node.read()).collect();
     }
 
-    /// Removes a vector ID from all index layers.
-    fn delete_from_layers(&mut self, id: &VectorID) {
-        // Remove the vector from the base layer.
-        let base_node = &mut self.base_layer[id.0 as usize];
-        let index = base_node.par_iter().position_first(|x| *x == *id);
-        if let Some(index) = index {
-            base_node.set(index, &INVALID);
+    /// Removes vector IDs from all index layers.
+    fn delete_from_layers(&mut self, ids: &[VectorID]) {
+        // Remove the vectors from the base layer.
+        for id in ids {
+            let base_node = &mut self.base_layer[id.0 as usize];
+            let index = base_node.par_iter().position_first(|x| *x == *id);
+            if let Some(index) = index {
+                base_node.set(index, &INVALID);
+            }
         }
 
         // Remove the vector from the upper layers.
@@ -665,11 +635,12 @@ impl Collection {
                 false => break,
             };
 
-            let node = &mut upper_layer[id.0 as usize];
-            let index = node.0.par_iter().position_first(|x| *x == *id);
-
-            if let Some(index) = index {
-                node.set(index, &INVALID);
+            for id in ids {
+                let node = &mut upper_layer[id.0 as usize];
+                let index = node.0.par_iter().position_first(|x| *x == *id);
+                if let Some(index) = index {
+                    node.set(index, &INVALID);
+                }
             }
         }
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -20,7 +20,18 @@ fn create_test_database(path: &str) -> Database {
 }
 
 fn create_collection() -> Collection {
-    let records = Record::many_random(DIMENSION, LEN);
+    let all_records = Record::many_random(DIMENSION, LEN);
+
+    // Split the records into two halves.
+    // The first half is used to build the collection.
+    // The second half is used to insert.
+    let mid = LEN / 2;
+    let first_half = &all_records[0..mid];
+    let second_half = &all_records[mid..LEN];
+
     let config = Config::default();
-    Collection::build(&config, &records).unwrap()
+    let mut collection = Collection::build(&config, first_half).unwrap();
+
+    collection.insert_many(second_half).unwrap();
+    collection
 }

--- a/src/tests/test_collection.rs
+++ b/src/tests/test_collection.rs
@@ -53,6 +53,20 @@ fn insert_data_type_object() {
 }
 
 #[test]
+fn insert_many() {
+    let mut collection = create_collection();
+
+    // Create records to insert.
+    let new_records = Record::many_random(DIMENSION, LEN);
+    let ids = collection.insert_many(&new_records).unwrap();
+
+    // Assert the new records are in the collection.
+    assert_eq!(collection.len(), 2 * LEN);
+    assert_eq!(ids.len(), LEN);
+    assert_eq!(ids[0], VectorID(LEN as u32));
+}
+
+#[test]
 fn delete() {
     let mut collection = create_collection();
 


### PR DESCRIPTION
### Purpose

This PR adds a new method to the `Collection` struct to insert multiple vector records at once. The implementation of this method is dedicated and optimized for inserting multiple vector records instead of a wrapper of the insert method with loop.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I have added a new test suite for both the functionality in Rust and Python testing inserting many vector records at once.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
