### PR TITLE
feat: return new vectorid after insert

### DIFF
--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -136,9 +136,9 @@ impl Collection {
         Self::build(config, &records)
     }
 
-    /// Inserts a vector record into the collection.
+    /// Inserts a vector record into the collection, and return `VectorID` if success.
     /// * `record`: Vector record to insert.
-    pub fn insert(&mut self, record: &Record) -> Result<(), Error> {
+    pub fn insert(&mut self, record: &Record) -> Result<VectorID, Error> {
         // Ensure the number of records is within the limit.
         if self.slots.len() == u32::MAX as usize {
             return Err(Error::collection_limit());
@@ -171,7 +171,7 @@ impl Collection {
         // the updated vectors data.
         self.insert_to_layers(&[id]);
 
-        Ok(())
+        Ok(id)
     }
 
     #[pyo3(name = "insert_many")]


### PR DESCRIPTION
### Purpose

Return the `VectorID` of the new vector record after the inserts.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

Straightforward and small scope functionality added.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
