### PR TITLE
feat: improve error type implementation

### DIFF
--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -302,7 +302,11 @@ impl Collection {
         let slots_iter = self.slots.as_slice().into_par_iter();
         let vector_id = match slots_iter.find_first(|id| id.is_valid()) {
             Some(id) => id,
-            None => return Err("Unable to initiate search.".into()),
+            None => {
+                let kind = ErrorKind::CollectionError;
+                let message = "Unable to initiate search.";
+                return Err(Error::new(&kind, message));
+            }
         };
 
         search.visited.resize_capacity(self.vectors.len());
@@ -446,24 +450,26 @@ impl Collection {
 
         // Ensure the number of records is within the limit.
         if records.len() >= u32::MAX as usize {
+            let kind = ErrorKind::CollectionError;
             let message = format!(
                 "The collection record limit is {}. Given: {}",
                 u32::MAX,
                 records.len()
             );
 
-            return Err(message.into());
+            return Err(Error::new(&kind, &message));
         }
 
         // Ensure that the vector dimension is consistent.
         let dimension = records[0].vector.len();
         if records.par_iter().any(|i| i.vector.len() != dimension) {
+            let kind = ErrorKind::CollectionError;
             let message = format!(
                 "The vector dimension is inconsistent. Expected: {}.",
                 dimension
             );
 
-            return Err(message.into());
+            return Err(Error::new(&kind, &message));
         }
 
         // Find the number of layers.
@@ -593,12 +599,13 @@ impl Collection {
 
         // Validate the vector dimension against the collection.
         if records.par_iter().any(|i| i.vector.len() != self.dimension) {
+            let kind = ErrorKind::CollectionError;
             let message = format!(
                 "The vector dimension is inconsistent. Expected: {}.",
                 self.dimension
             );
 
-            return Err(message.into());
+            return Err(Error::new(&kind, &message));
         }
 
         // Create new vector IDs for the records.
@@ -634,7 +641,9 @@ impl Collection {
     pub fn set_dimension(&mut self, dimension: usize) -> Result<(), Error> {
         // This can only be set if the collection is empty.
         if !self.vectors.is_empty() {
-            return Err("The collection must be empty.".into());
+            let kind = ErrorKind::CollectionError;
+            let message = "Collection must be empty to set dimension.";
+            return Err(Error::new(&kind, message));
         }
 
         self.dimension = dimension;

--- a/src/func/distance.rs
+++ b/src/func/distance.rs
@@ -23,7 +23,7 @@ impl Distance {
             "dot" => Ok(Distance::Dot),
             "euclidean" => Ok(Distance::Euclidean),
             "cosine" => Ok(Distance::Cosine),
-            _ => Err("Distance function not supported.".into()),
+            _ => Err(Error::invalid_distance()),
         }
     }
 

--- a/src/func/err.rs
+++ b/src/func/err.rs
@@ -2,6 +2,7 @@
 use bincode::ErrorKind as BincodeError;
 use sled::Error as SledError;
 use std::error::Error as StandardError;
+use std::fmt::{Display, Formatter, Result};
 use std::io::Error as IOError;
 
 #[cfg(feature = "py")]
@@ -10,27 +11,45 @@ use super::*;
 #[cfg(feature = "py")]
 use pyo3::exceptions::PyValueError;
 
-/// A custom error type containing the error message.
+/// The type of error.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorKind {
+    StandardError,
+    IOError,
+    DatabaseError,
+    CollectionError,
+    DistanceError,
+    SerializationError,
+}
+
+/// A custom error object with error type and message.
 #[derive(Debug)]
-pub struct Error(String);
+pub struct Error {
+    /// Type of error.
+    pub kind: ErrorKind,
+    /// Why the error occurred.
+    pub message: String,
+}
 
 impl Error {
     /// Create a new error with the given message.
-    pub fn new(message: &str) -> Self {
-        message.into()
+    pub fn new(kind: &ErrorKind, message: &str) -> Self {
+        Self { kind: kind.clone(), message: message.to_string() }
     }
 
     /// Returns the error message.
     pub fn message(&self) -> &str {
-        &self.0
+        &self.message
     }
 
-    // Common collection errors.
+    // Common errors.
 
     /// Creates error: The collection is not found.
     pub fn collection_not_found() -> Self {
         let message = "The collection is not found.";
-        message.into()
+        let kind = ErrorKind::DatabaseError;
+        Error::new(&kind, message)
     }
 
     /// Creates error when the collection record limit is reached.
@@ -38,38 +57,42 @@ impl Error {
         let max = u32::MAX;
         let brief = "The collection limit is reached.";
         let detail = format!("The max number of records is {max}.");
-        let message = format!("{brief} {detail}");
-        message.into()
-    }
 
-    // Common record errors.
+        let message = format!("{brief} {detail}");
+        let kind = ErrorKind::CollectionError;
+        Error::new(&kind, &message)
+    }
 
     /// Creates error when vector record is not found.
     pub fn record_not_found() -> Self {
         let message = "The vector record is not found.";
-        message.into()
+        let kind = ErrorKind::CollectionError;
+        Error::new(&kind, message)
     }
 
     /// Creates error when getting vector with invalid dimension.
     pub fn invalid_dimension(found: usize, expected: usize) -> Self {
         let brief = "Invalid vector dimension.";
         let detail = format!("Expected {expected}, found {found}.");
+
         let message = format!("{brief} {detail}");
-        message.into()
+        let kind = ErrorKind::CollectionError;
+        Error::new(&kind, &message)
+    }
+
+    /// Error when the distance function is not supported.
+    pub fn invalid_distance() -> Self {
+        let message = format!("Distance function not supported.");
+        let kind = ErrorKind::DistanceError;
+        Error::new(&kind, &message)
     }
 }
 
-// Quality of life conversions to Error type.
-
-impl From<String> for Error {
-    fn from(err: String) -> Self {
-        Error(err)
-    }
-}
-
-impl From<&str> for Error {
-    fn from(err: &str) -> Self {
-        Error(err.to_string())
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        let kind = &self.kind;
+        let message = &self.message;
+        write!(f, "{kind:?}: {message}")
     }
 }
 
@@ -77,31 +100,35 @@ impl From<&str> for Error {
 
 impl From<Box<dyn StandardError>> for Error {
     fn from(err: Box<dyn StandardError>) -> Self {
-        Error(err.to_string())
+        let kind = ErrorKind::StandardError;
+        Error::new(&kind, &err.to_string())
     }
 }
 
 impl From<SledError> for Error {
     fn from(err: SledError) -> Self {
-        Error(err.to_string())
+        let kind = ErrorKind::DatabaseError;
+        Error::new(&kind, &err.to_string())
     }
 }
 
 impl From<IOError> for Error {
     fn from(err: IOError) -> Self {
-        Error(err.to_string())
+        let kind = ErrorKind::IOError;
+        Error::new(&kind, &err.to_string())
     }
 }
 
 impl From<Box<BincodeError>> for Error {
     fn from(err: Box<BincodeError>) -> Self {
-        Error(err.to_string())
+        let kind = ErrorKind::SerializationError;
+        Error::new(&kind, &err.to_string())
     }
 }
 
 #[cfg(feature = "py")]
 impl From<Error> for PyErr {
     fn from(err: Error) -> Self {
-        PyErr::new::<PyValueError, String>(err.0)
+        PyErr::new::<PyValueError, String>(err.message)
     }
 }

--- a/src/func/err.rs
+++ b/src/func/err.rs
@@ -35,7 +35,7 @@ pub struct Error {
 impl Error {
     /// Create a new error with the given message.
     pub fn new(kind: &ErrorKind, message: &str) -> Self {
-        Self { kind: kind.clone(), message: message.to_string() }
+        Self { kind: *kind, message: message.to_string() }
     }
 
     /// Returns the error message.
@@ -82,9 +82,9 @@ impl Error {
 
     /// Error when the distance function is not supported.
     pub fn invalid_distance() -> Self {
-        let message = format!("Distance function not supported.");
+        let message = "Distance function not supported.";
         let kind = ErrorKind::DistanceError;
-        Error::new(&kind, &message)
+        Error::new(&kind, message)
     }
 }
 


### PR DESCRIPTION
### Purpose

In addition to resolving issue #45, this PR improves the overall implementation of OasysDB native error type. This PR introduce a new field to the error struct, `kind`. This field represents the type/source of error happening in OasysDB.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

There is no new functionality added.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
