### PR TITLE
fix: improve config

### DIFF
--- a/py/oasysdb/collection.pyi
+++ b/py/oasysdb/collection.pyi
@@ -38,6 +38,13 @@ class Config:
         - distance: euclidean
         """
 
+    @staticmethod
+    def default() -> Config:
+        """Returns a default configuration object.
+        This is an alias of create_default method and
+        shared the same implementation.
+        """
+
 
 class Record:
     """The vector record to store in the collection.

--- a/py/oasysdb/collection.pyi
+++ b/py/oasysdb/collection.pyi
@@ -34,7 +34,7 @@ class Config:
         Default values:
         - ef_construction: 40
         - ef_search: 15
-        - ml: 0.3
+        - ml: 0.2885
         - distance: euclidean
         """
 

--- a/py/tests/test_collection.py
+++ b/py/tests/test_collection.py
@@ -7,7 +7,7 @@ LEN = 100
 def create_test_collection() -> Collection:
     """Creates a collection with random records for testing."""
     records = Record.many_random(dimension=DIMENSION, len=LEN)
-    config = Config.create_default()
+    config = Config.default()
     collection = Collection.from_records(config=config, records=records)
 
     assert collection.len() == len(records)

--- a/py/tests/test_collection.py
+++ b/py/tests/test_collection.py
@@ -21,7 +21,7 @@ def test_create_config():
     config = Config(
         ef_construction=40,
         ef_search=15,
-        ml=0.3,
+        ml=0.2885,
         distance="euclidean"
     )
 

--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -55,6 +55,12 @@ impl Config {
         Self::default()
     }
 
+    #[staticmethod]
+    #[pyo3(name = "default")]
+    fn py_default() -> Self {
+        Self::default()
+    }
+
     fn __repr__(&self) -> String {
         format!("{:?}", self)
     }

--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -84,13 +84,13 @@ impl Default for Config {
     /// Default configuration for the collection index.
     /// * `ef_construction`: 40
     /// * `ef_search`: 15
-    /// * `ml`: 0.3
+    /// * `ml`: 0.2885
     /// * `distance`: euclidean
     fn default() -> Self {
         Self {
             ef_construction: 40,
             ef_search: 15,
-            ml: 0.3,
+            ml: 0.2885,
             distance: Distance::Euclidean,
         }
     }


### PR DESCRIPTION
### Purpose

This PR:

- Change the `ml` field default value for `Config` from 0.3 to 0.2885 which is closer to the optimal value of `1/ln(M)` where M is 32.
- Add `default()` method to Python as an alias for `create_default()`.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
