### PR TITLE
feat: add empty impl std error for error

### DIFF
--- a/src/func/err.rs
+++ b/src/func/err.rs
@@ -98,6 +98,8 @@ impl Display for Error {
 
 // Interoperability with other error types.
 
+impl StandardError for Error {}
+
 impl From<Box<dyn StandardError>> for Error {
     fn from(err: Box<dyn StandardError>) -> Self {
         let kind = ErrorKind::StandardError;


### PR DESCRIPTION
### Purpose

Please check issue  #68 for more information about this PR.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

To test this functionality:

1. Create a function that returns `anyhow::Result`.
2. Use any method that returns OasysDB native error, `Result<_, Error>`, such as `Collection.build` method.
3. Test propagate OasysDB error using the `?` operator.

```rs
fn test() -> anyhow::Result<()> {
    let config = Config::default();
    let records = vec![];
    Collection::build(&config, &records)?;
    Ok(())
}
```

### Chore checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added comments to most of my code, particularly in hard-to-understand areas.
