### PR TITLE
feat: add conversion from json value to metadata vice versa

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -41,7 +41,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo test
-        run: cargo test
+        run: cargo test --all-features
 
   run-python-tests:
     name: Run Python tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde-big-array",
+ "serde_json",
  "simsimd",
  "sled",
 ]
@@ -542,9 +543,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -612,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -752,9 +753,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
@@ -770,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -781,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -823,9 +824,9 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ bincode = "1.3.3"
 
 # Interoperability.
 pyo3 = { version = "0.20.2", optional = true }
+serde_json = { version = "1.0.116", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -46,6 +47,7 @@ jemallocator = "0.5.4"
 jemalloc-ctl = "0.5.4"
 
 [features]
+json = ["dep:serde_json"]
 py = ["dep:pyo3"]
 
 [profile.release]

--- a/src/func/metadata.rs
+++ b/src/func/metadata.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(feature = "json")]
+use serde_json::{Map, Number, Value};
+
 /// The metadata associated with a vector record.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum Metadata {
@@ -68,6 +71,90 @@ where
         let iter = value.into_iter();
         let obj = iter.map(|(k, v)| (k.into(), v.into())).collect();
         Metadata::Object(obj)
+    }
+}
+
+// This implementation allows conversion from
+// JSON Value type to the Metadata enum.
+#[cfg(feature = "json")]
+impl From<Value> for Metadata {
+    fn from(value: Value) -> Self {
+        // Cast JSON number to Metadata float or integer.
+        let convert_number = |number: Number| {
+            // Check if the number is float. If not, it's an integer.
+            if number.is_f64() {
+                let float = number.as_f64().unwrap();
+                Metadata::Float(float as f32)
+            } else {
+                let int = number.as_i64().unwrap();
+                Metadata::Integer(int as usize)
+            }
+        };
+
+        // Cast JSON array to Metadata array.
+        let convert_array = |array: Vec<Value>| {
+            let vec = array.into_iter().map(|v| v.into()).collect();
+            Metadata::Array(vec)
+        };
+
+        // Cast JSON object to Metadata object.
+        let convert_object = |object: Map<String, Value>| {
+            let map = object
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect::<HashMap<String, Metadata>>();
+            Metadata::Object(map)
+        };
+
+        match value {
+            Value::String(text) => Metadata::Text(text),
+            Value::Number(number) => convert_number(number),
+            Value::Array(array) => convert_array(array),
+            Value::Object(object) => convert_object(object),
+            _ => panic!("Unsupported JSON type for the metadata."),
+        }
+    }
+}
+
+// This implementation allows conversion from
+// the native Metadata enum to JSON Value.
+#[cfg(feature = "json")]
+impl From<Metadata> for Value {
+    fn from(metadata: Metadata) -> Self {
+        // Convert Metadata integer to JSON number.
+        let convert_integer = |int: usize| {
+            let number = Number::from(int as i64);
+            Value::Number(number)
+        };
+
+        // Convert Metadata float to JSON number.
+        let convert_float = |float: f32| {
+            let number = Number::from_f64(float as f64).unwrap();
+            Value::Number(number)
+        };
+
+        // Convert Metadata array to JSON array.
+        let convert_array = |arr: Vec<Metadata>| {
+            let vec = arr.into_iter().map(|v| v.into()).collect();
+            Value::Array(vec)
+        };
+
+        // Convert Metadata object to JSON object.
+        let convert_object = |obj: HashMap<String, Metadata>| {
+            let map = obj
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect::<Map<String, Value>>();
+            Value::Object(map)
+        };
+
+        match metadata {
+            Metadata::Text(text) => Value::String(text),
+            Metadata::Integer(int) => convert_integer(int),
+            Metadata::Float(float) => convert_float(float),
+            Metadata::Array(array) => convert_array(array),
+            Metadata::Object(object) => convert_object(object),
+        }
     }
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod test_collection;
 mod test_database;
 mod test_distance;
+mod test_metadata;
 
 use crate::prelude::*;
 use rayon::iter::*;

--- a/src/tests/test_metadata.rs
+++ b/src/tests/test_metadata.rs
@@ -1,0 +1,29 @@
+#[allow(unused_imports)]
+use super::*;
+
+#[cfg(feature = "json")]
+use serde_json::{json, Value};
+
+#[cfg(feature = "json")]
+#[test]
+fn json_value_to_metadata() {
+    let map = HashMap::from([("key", "value")]);
+    let value = json!(map);
+
+    let metadata = Metadata::from(map);
+    let metadata_from_value = Metadata::from(value);
+
+    assert_eq!(metadata, metadata_from_value);
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn metadata_to_json_value() {
+    let map = HashMap::from([("key", "value")]);
+    let value = json!(map);
+
+    let metadata = Metadata::from(map);
+    let value_from_metadata = Value::from(metadata);
+
+    assert_eq!(value, value_from_metadata);
+}


### PR DESCRIPTION
### Purpose

For more information about this PR and what it solves, please check issue #69.

One thing to add is that this interoperability is gated behind the `json` feature.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I added new test suites to test conversions between `Metadata` and `serde_json::Value`.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
