### PR TITLE
feat: add normalized cosine distance

### DIFF
--- a/py/oasysdb/collection.pyi
+++ b/py/oasysdb/collection.pyi
@@ -12,6 +12,12 @@ class Config:
     - ef_search: Nodes to consider during the search.
     - ml: Layer multiplier of the HNSW index.
     - distance: Distance metric function.
+
+    Distance metrics:
+    - euclidean
+    - dot
+    - cosine
+    - norm_cosine
     """
 
     ef_construction: int

--- a/src/func/distance.rs
+++ b/src/func/distance.rs
@@ -10,6 +10,8 @@ pub enum Distance {
     Euclidean,
     /// Cosine similarity function.
     Cosine,
+    /// Cosine function for normalized vectors.
+    NormCosine,
 }
 
 impl Distance {
@@ -18,11 +20,13 @@ impl Distance {
     /// * `dot`: Dot product function.
     /// * `euclidean`: Euclidean distance function.
     /// * `cosine`: Cosine similarity function.
+    /// * `norm_cosine`: Cosine function for normalized vectors.
     pub fn from(distance: &str) -> Result<Self, Error> {
         match distance {
             "dot" => Ok(Distance::Dot),
             "euclidean" => Ok(Distance::Euclidean),
             "cosine" => Ok(Distance::Cosine),
+            "norm_cosine" => Ok(Distance::NormCosine),
             _ => Err(Error::invalid_distance()),
         }
     }
@@ -34,6 +38,7 @@ impl Distance {
             Distance::Dot => Distance::dot(a, b),
             Distance::Euclidean => Distance::euclidean(a, b),
             Distance::Cosine => Distance::cosine(a, b),
+            Distance::NormCosine => Distance::dot(a, b),
         }
     }
 

--- a/src/func/distance.rs
+++ b/src/func/distance.rs
@@ -76,6 +76,7 @@ impl IntoPy<Py<PyAny>> for Distance {
             Distance::Dot => "dot".into_py(py),
             Distance::Euclidean => "euclidean".into_py(py),
             Distance::Cosine => "cosine".into_py(py),
+            Distance::NormCosine => "norm_cosine".into_py(py),
         }
     }
 }

--- a/src/tests/test_distance.rs
+++ b/src/tests/test_distance.rs
@@ -8,8 +8,10 @@ fn distance_calculation() {
     let dot = Distance::Dot.calculate(&a, &b);
     let euclidean = Distance::Euclidean.calculate(&a, &b);
     let cosine = Distance::Cosine.calculate(&a, &b);
+    let norm_cosine = Distance::NormCosine.calculate(&a, &b);
 
     assert_eq!(dot, 44.0);
     assert_eq!(euclidean, 1.7320508);
     assert_eq!(cosine, 0.99385864);
+    assert_eq!(dot, norm_cosine);
 }


### PR DESCRIPTION
### Purpose

Please check issue #70 for more information about this PR.

### Approach

This PR adds a new option `Distance::NormCosine` or in string form, `norm_cosine` that allows a faster calculation of normalized vectors by eliminating calculations of the vector magnitude.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I added a test to the distance calculation result.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
