### PR TITLE
feat: add collection true search benchmark

### DIFF
--- a/bench/main.rs
+++ b/bench/main.rs
@@ -15,7 +15,7 @@ const COLLECTION_SIZE: usize = 1_000_000;
 const DIMENSION: usize = 128;
 
 fn bench_search_collection(criterion: &mut Criterion) {
-    let id = "Search collection";
+    let id = "search collection";
 
     // Create the collection.
     let collection = build_test_collection(DIMENSION, COLLECTION_SIZE);
@@ -28,8 +28,30 @@ fn bench_search_collection(criterion: &mut Criterion) {
         black_box(collection.search(&vector, 10).unwrap());
     };
 
-    criterion.bench_function(id, |bencher| bencher.iter(routine));
+    criterion.bench_function(id, |b| b.iter(routine));
 }
 
-criterion_group!(bench, bench_search_collection);
-criterion_main!(bench);
+fn bench_true_search_collection(criterion: &mut Criterion) {
+    let id = "true search collection";
+
+    // Create the collection.
+    let collection = build_test_collection(DIMENSION, COLLECTION_SIZE);
+
+    // Create a random vector to search for.
+    let vector = Vector::random(DIMENSION);
+
+    // Benchmark the search speed.
+    let routine = || {
+        black_box(collection.true_search(&vector, 10).unwrap());
+    };
+
+    criterion.bench_function(id, |b| b.iter(routine));
+}
+
+criterion_group!(
+    collection,
+    bench_search_collection,
+    bench_true_search_collection
+);
+
+criterion_main!(collection);


### PR DESCRIPTION
### Purpose

This PR adds a new benchmark function built-in using `criterion` Rust crate to measure the `Collection.true_search` performance.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

There's no new feature added.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
