### PR TITLE
feat: add vector id utility methods

### DIFF
--- a/src/func/vector.rs
+++ b/src/func/vector.rs
@@ -18,6 +18,16 @@ impl VectorID {
     pub fn is_valid(&self) -> bool {
         self.0 != u32::MAX
     }
+
+    /// Returns the vector ID as u32 type.
+    pub fn to_u32(&self) -> u32 {
+        self.0
+    }
+
+    /// Returns the vector ID as usize type.
+    pub fn to_usize(&self) -> usize {
+        self.0 as usize
+    }
 }
 
 impl From<u32> for VectorID {


### PR DESCRIPTION
### Purpose

This PR adds utility methods to `VectorID` struct:

- `to_u32`: Returns the VectorID as u32.
- `to_usize`: Returns the VectorID as usize.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

The functionality is very simple.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
