### PR TITLE
fix: search distance calculation

### DIFF
--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -22,5 +22,9 @@ fn main() {
     // Search for the nearest neighbors.
     let query = Vector::random(dimension);
     let result = collection.search(&query, 5).unwrap();
-    println!("Nearest ID: {}", result[0].id);
+
+    for res in result {
+        let (id, distance) = (res.id, res.distance);
+        println!("{distance:.5} | ID: {id}");
+    }
 }

--- a/py/tests/test_collection.py
+++ b/py/tests/test_collection.py
@@ -176,3 +176,20 @@ def test_list_records():
     assert len(records) == collection.len()
     assert all(isinstance(k, VectorID) for k in records.keys())
     assert all(isinstance(v, Record) for v in records.values())
+
+
+def test_collection_distance_cosine():
+    config = Config.create_default()
+    config.distance = "cosine"
+    collection = Collection(config=config)
+
+    # Insert one record.
+    record = Record.random(dimension=DIMENSION)
+    collection.insert(record)
+
+    # Search for the record.
+    query = Vector.random(dimension=DIMENSION)
+    results = collection.search(query, n=1)
+    true_results = collection.true_search(query, n=1)
+
+    assert results[0].distance == true_results[0].distance

--- a/py/tests/test_collection.py
+++ b/py/tests/test_collection.py
@@ -178,18 +178,44 @@ def test_list_records():
     assert all(isinstance(v, Record) for v in records.values())
 
 
+def test_collection_distance_euclidean():
+    config = Config.default()
+    collection = Collection(config=config)
+
+    # Insert records.
+    k = 5
+    records = Record.many_random(dimension=DIMENSION, len=k)
+    collection.insert_many(records)
+
+    # Search for the record.
+    query = Vector.random(dimension=DIMENSION)
+    results = collection.search(query, n=k)
+
+    # Sort result based on distance ascending.
+    sort = sorted(results, key=lambda x: x.distance)
+
+    for i in range(k):
+        assert results[i].distance == sort[i].distance
+
+
 def test_collection_distance_cosine():
     config = Config.create_default()
     config.distance = "cosine"
     collection = Collection(config=config)
 
-    # Insert one record.
-    record = Record.random(dimension=DIMENSION)
-    collection.insert(record)
+    # Insert records.
+    k = 5
+    records = Record.many_random(dimension=DIMENSION, len=k)
+    collection.insert_many(records)
 
     # Search for the record.
     query = Vector.random(dimension=DIMENSION)
-    results = collection.search(query, n=1)
-    true_results = collection.true_search(query, n=1)
+    results = collection.search(query, n=k)
+    true_results = collection.true_search(query, n=k)
 
-    assert results[0].distance == true_results[0].distance
+    # Sort result based on distance descending.
+    sort = sorted(results, key=lambda x: x.distance, reverse=True)
+
+    for i in range(k):
+        assert results[i].distance == true_results[i].distance
+        assert results[i].distance == sort[i].distance

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,11 @@ fn main() {
     // Search for the nearest neighbors.
     let query = Vector::random(dimension);
     let result = collection.search(&query, 5).unwrap();
-    println!("Nearest ID: {}", result[0].id);
+
+    for res in result {
+        let (id, distance) = (res.id, res.distance);
+        println!("{distance:.5} | ID: {id}");
+    }
 }
 ```
 

--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -294,7 +294,7 @@ impl Collection {
         vector: &Vector,
         n: usize,
     ) -> Result<Vec<SearchResult>, Error> {
-        let mut search = Search::default();
+        let mut search = Search::new(0, self.config.distance);
 
         // Early return if the collection is empty.
         if self.vectors.is_empty() {
@@ -528,7 +528,7 @@ impl Collection {
 
         // Create index constructor.
 
-        let search_pool = SearchPool::new(vectors.len());
+        let search_pool = SearchPool::new(vectors.len(), config.distance);
         let mut upper_layers = vec![vec![]; top_layer.0];
         let base_layer = vectors
             .par_iter()
@@ -694,11 +694,14 @@ impl Collection {
 
         // Create a new index construction state.
         let state = IndexConstruction {
-            base_layer: base_layer.as_slice(),
-            search_pool: SearchPool::new(self.vectors.len()),
             top_layer,
+            base_layer: base_layer.as_slice(),
             vectors: &self.vectors,
             config: &self.config,
+            search_pool: SearchPool::new(
+                self.vectors.len(),
+                self.config.distance,
+            ),
         };
 
         // Insert all vectors into the state.

--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -370,8 +370,20 @@ impl Collection {
             nearest.push(res);
         }
 
-        // Sort the nearest neighbors by distance.
-        nearest.sort_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
+        // Sort the nearest neighbors by distance depending on the metric.
+        // For Euclidean: sort by ascending order since smaller is better.
+        match self.config.distance {
+            Distance::Euclidean => {
+                nearest.sort_by(|a, b| {
+                    a.distance.partial_cmp(&b.distance).unwrap()
+                });
+            }
+            _ => {
+                nearest.sort_by(|a, b| {
+                    b.distance.partial_cmp(&a.distance).unwrap()
+                });
+            }
+        };
 
         // Remove irrelevant results and truncate the list.
         let mut res = self.truncate_irrelevant_result(nearest);

--- a/src/func/utils.rs
+++ b/src/func/utils.rs
@@ -258,9 +258,16 @@ impl Search {
         links: usize,
     ) {
         while let Some(Reverse(candidate)) = self.candidates.pop() {
-            // Skip candidates that are too far.
+            // Skip candidates conditionally.
+            // For Euclidean metrics, skip candidate with larger distances
+            // because 0.0 is the smallest and best distance.
+            // For other metrics, the bigger the distance, the better.
             if let Some(furthest) = self.nearest.last() {
-                if candidate.distance > furthest.distance {
+                if let Distance::Euclidean = self.distance {
+                    if candidate.distance > furthest.distance {
+                        break;
+                    }
+                } else if candidate.distance < furthest.distance {
                     break;
                 }
             }


### PR DESCRIPTION
### Purpose

This PR is to fix the bug in this Google Colab notebook:
https://colab.research.google.com/drive/1zQtpXkkWASt_37aiA7m5ZZcMqBnUGxOZ?usp=sharing

In short, the search result distance returned is that of Euclidean instead of the configured Cosine.

### Cause

https://github.com/oasysai/oasysdb/blob/b04772b5dc9fc27faab3e2c42a1f39885f9c2628/src/func/collection.rs#L297

https://github.com/oasysai/oasysdb/blob/b04772b5dc9fc27faab3e2c42a1f39885f9c2628/src/func/utils.rs#L337-L349

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I added a new test in Python to check the result.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
