### PR TITLE
chore: simplify oasysdb test suites

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUST_TEST_THREADS = "1"

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -14,6 +14,21 @@ on:
       - main
 
 jobs:
+  rustfmt-format:
+    name: Check code formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Run cargo fmt with check
+        run: cargo fmt -- --check
+
   clippy-lint:
     name: Lint code with Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -41,7 +41,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo test
-        run: cargo test --all-features
+        run: cargo test --all-features -- --test-threads 1
 
   run-python-tests:
     name: Run Python tests

--- a/py/tests/test_database.py
+++ b/py/tests/test_database.py
@@ -6,10 +6,10 @@ DIMENSION = 128
 LEN = 100
 
 
-def create_test_database(path: str) -> Database:
+def create_test_database() -> Database:
     """Creates a new test database with an initial collection."""
 
-    db = Database.new(path)
+    db = Database.new("data/py")
     assert db.is_empty()
 
     # Create a test collection with random records.
@@ -25,24 +25,24 @@ def create_test_database(path: str) -> Database:
 
 
 def test_open():
-    db = Database(path="data/101")
+    db = Database(path="data/mt")
     assert db.is_empty()
 
 
 def test_new():
-    db = create_test_database(path="data/102")
+    db = create_test_database()
     assert not db.is_empty()
     assert db.len() == 1
 
 
 def test_get_collection():
-    db = create_test_database(path="data/103")
+    db = create_test_database()
     collection = db.get_collection(name=NAME)
     assert collection.len() == LEN
 
 
 def test_save_collection():
-    db = create_test_database(path="data/104")
+    db = create_test_database()
 
     # Create a new collection and save it to the database.
     config = Config.create_default()
@@ -53,6 +53,6 @@ def test_save_collection():
 
 
 def test_delete_collection():
-    db = create_test_database(path="data/105")
+    db = create_test_database()
     db.delete_collection(name=NAME)
     assert db.is_empty()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,8 +13,8 @@ const LEN: usize = 100;
 /// The test database initial collection name.
 const NAME: &str = "vectors";
 
-fn create_test_database(path: &str) -> Database {
-    let mut db = Database::new(path).unwrap();
+fn create_test_database() -> Database {
+    let mut db = Database::new("data/rs").unwrap();
     let collection = create_collection();
     db.save_collection(NAME, &collection).unwrap();
     db

--- a/src/tests/test_collection.rs
+++ b/src/tests/test_collection.rs
@@ -1,6 +1,14 @@
 use super::*;
 
 #[test]
+fn new_with_distance() {
+    let mut config = Config::default();
+    config.distance = Distance::Cosine;
+    let mut collection = Collection::new(&config);
+    collection.insert(&Record::random(DIMENSION)).unwrap();
+}
+
+#[test]
 fn build_large() {
     let len = 10000;
     let records = Record::many_random(DIMENSION, len);

--- a/src/tests/test_database.rs
+++ b/src/tests/test_database.rs
@@ -2,27 +2,21 @@ use super::*;
 
 #[test]
 fn new() {
-    let db = Database::new("data/001").unwrap();
+    let db = Database::new("data/rs").unwrap();
     assert_eq!(db.len(), 0);
-}
-#[test]
-fn new_with_distance() {
-    let mut config = Config::default();
-    config.distance = Distance::Cosine;
-    let mut collection = Collection::new(&config);
-    collection.insert(&Record::random(DIMENSION)).unwrap();
 }
 
 #[test]
 fn get_collection() {
-    let db = create_test_database("data/002");
+    let db = create_test_database();
     let collection = db.get_collection(NAME).unwrap();
     assert_eq!(collection.len(), LEN);
 }
 
 #[test]
 fn save_collection_new() {
-    let mut db = Database::new("data/003").unwrap();
+    let mut db = Database::new("data/rs").unwrap();
+    let old_count = db.len();
 
     // Create a collection from scratch.
     let config = Config::default();
@@ -34,12 +28,12 @@ fn save_collection_new() {
 
     db.save_collection("new", &collection).unwrap();
     assert_eq!(collection.len(), 1);
-    assert_eq!(db.len(), 1);
+    assert_eq!(db.len(), old_count + 1);
 }
 
 #[test]
 fn save_collection_update() {
-    let mut db = create_test_database("data/004");
+    let mut db = create_test_database();
 
     // Update the collection.
     let mut collection = db.get_collection(NAME).unwrap();
@@ -52,7 +46,7 @@ fn save_collection_update() {
 
 #[test]
 fn delete_collection() {
-    let mut db = create_test_database("data/005");
+    let mut db = create_test_database();
     db.delete_collection(NAME).unwrap();
     assert_eq!(db.len(), 0);
 }

--- a/src/tests/test_database.rs
+++ b/src/tests/test_database.rs
@@ -16,7 +16,7 @@ fn get_collection() {
 #[test]
 fn save_collection_new() {
     let mut db = Database::new("data/rs").unwrap();
-    let old_count = db.len();
+    let len = db.len();
 
     // Create a collection from scratch.
     let config = Config::default();
@@ -28,7 +28,7 @@ fn save_collection_new() {
 
     db.save_collection("new", &collection).unwrap();
     assert_eq!(collection.len(), 1);
-    assert_eq!(db.len(), old_count + 1);
+    assert_eq!(db.len(), len + 1);
 }
 
 #[test]


### PR DESCRIPTION
### Purpose

This PR uses single-threaded tests to simplify testing OasysDB persistence. Previously, due to using multi-threaded test, test creators has to essentially create an ID for their test to ensure that different test opens a different database file.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.