### PR TITLE
feat: add insert benchmark

### DIFF
--- a/bench/main.rs
+++ b/bench/main.rs
@@ -48,12 +48,6 @@ fn bench_true_search_collection(criterion: &mut Criterion) {
     criterion.bench_function(id, |b| b.iter(routine));
 }
 
-criterion_group!(
-    collection_search,
-    bench_search_collection,
-    bench_true_search_collection
-);
-
 fn bench_insert_to_collection(criterion: &mut Criterion) {
     let id = "insert to collection";
 
@@ -69,5 +63,11 @@ fn bench_insert_to_collection(criterion: &mut Criterion) {
     });
 }
 
-criterion_group!(collection_insert, bench_insert_to_collection);
-criterion_main!(collection_search, collection_insert);
+criterion_group!(
+    collection,
+    bench_search_collection,
+    bench_true_search_collection,
+    bench_insert_to_collection
+);
+
+criterion_main!(collection);

--- a/bench/main.rs
+++ b/bench/main.rs
@@ -49,9 +49,25 @@ fn bench_true_search_collection(criterion: &mut Criterion) {
 }
 
 criterion_group!(
-    collection,
+    collection_search,
     bench_search_collection,
     bench_true_search_collection
 );
 
-criterion_main!(collection);
+fn bench_insert_to_collection(criterion: &mut Criterion) {
+    let id = "insert to collection";
+
+    // Create the initial collection.
+    let mut collection = build_test_collection(DIMENSION, COLLECTION_SIZE);
+
+    // Benchmark the insert speed.
+    let record = Record::random(DIMENSION);
+    criterion.bench_function(id, |bencher| {
+        bencher.iter(|| {
+            black_box(collection.insert(&record).unwrap());
+        })
+    });
+}
+
+criterion_group!(collection_insert, bench_insert_to_collection);
+criterion_main!(collection_search, collection_insert);


### PR DESCRIPTION
### Purpose

This PR adds a benchmark to measure the collection insert operation. This is the result I got from running it locally on Apple M2 CPU with 16GB of RAM:

- Collection size: 1,000,000
  Vector dimension: 128
  Insert performance: 45ms

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
