### PR TITLE
fix: large dirty io buffers with flush

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +382,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "inventory"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "is-terminal"
@@ -418,6 +513,7 @@ version = "0.4.4"
 dependencies = [
  "bincode",
  "criterion",
+ "futures",
  "jemalloc-ctl",
  "jemallocator",
  "ordered-float",
@@ -508,6 +604,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,15 +666,17 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
+ "inventory",
  "libc",
  "memoffset",
  "parking_lot 0.12.1",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -569,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -579,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -589,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -601,12 +717,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -798,6 +915,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9b7427cabeed25b18b43cc7d7ec466d8d1953a13ed56c46dc414c99ca4754e"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,13 @@ serde-big-array = "0.5.1"
 bincode = "1.3.3"
 
 # Interoperability.
-pyo3 = { version = "0.20.2", optional = true }
 serde_json = { version = "1.0.116", optional = true }
+
+# Python bindings tool.
+[dependencies.pyo3]
+version = "0.21.2"
+features = ["experimental-async", "gil-refs", "multiple-pymethods"]
+optional = true
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -45,6 +50,9 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 # Memory management.
 jemallocator = "0.5.4"
 jemalloc-ctl = "0.5.4"
+
+# Async handling.
+futures = "0.3.30"
 
 [features]
 json = ["dep:serde_json"]

--- a/py/oasysdb/database.pyi
+++ b/py/oasysdb/database.pyi
@@ -42,6 +42,16 @@ class Database:
         - name: Collection name.
         """
 
+    def flush(self) -> int:
+        """Flushes dirty IO buffers and calls fsync.
+
+        Returns:
+        Bytes flushed.
+        """
+
+    def async_flush(self) -> int:
+        """Asynchronously performs the flush operation."""
+
     def len(self) -> int:
         """Returns the number of collections in the database."""
 

--- a/py/tests/test_database.py
+++ b/py/tests/test_database.py
@@ -1,3 +1,4 @@
+import asyncio
 from oasysdb.prelude import Record, Collection, Config, Database
 
 
@@ -56,3 +57,13 @@ def test_delete_collection():
     db = create_test_database()
     db.delete_collection(name=NAME)
     assert db.is_empty()
+
+
+def test_flush():
+    db = create_test_database()
+    assert db.flush() > 0
+
+
+def test_async_flush():
+    db = create_test_database()
+    assert asyncio.run(db.async_flush()) > 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest==8.0.2
 black==24.3.0
 flake8==7.0.0
+asyncio==3.4.3

--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -7,21 +7,29 @@ pub struct Database {
     count: usize,
 }
 
-#[cfg_attr(feature = "py", pymethods)]
+/// Python only methods.
+#[cfg(feature = "py")]
+#[pymethods]
 impl Database {
-    #[cfg(feature = "py")]
     #[staticmethod]
     #[pyo3(name = "new")]
     fn py_new(path: &str) -> PyResult<Self> {
         Self::new(path).map_err(|e| e.into())
     }
 
-    #[cfg(feature = "py")]
     #[new]
     fn py_open(path: &str) -> PyResult<Self> {
         Self::open(path).map_err(|e| e.into())
     }
 
+    fn __len__(&self) -> usize {
+        self.len()
+    }
+}
+
+// Mixed Rust and Python methods.
+#[cfg_attr(feature = "py", pymethods)]
+impl Database {
     /// Gets a collection from the database.
     /// * `name` - Name of the collection.
     pub fn get_collection(&self, name: &str) -> Result<Collection, Error> {
@@ -87,11 +95,6 @@ impl Database {
     pub async fn async_flush(&self) -> Result<usize, Error> {
         let bytes = self.collections.flush_async().await?;
         Ok(bytes)
-    }
-
-    #[cfg(feature = "py")]
-    fn __len__(&self) -> usize {
-        self.len()
     }
 }
 

--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -76,6 +76,20 @@ impl Database {
         self.count == 0
     }
 
+    /// Flushes dirty IO buffers from the database.
+    /// Returns bytes flushed.
+    pub fn flush(&self) -> Result<usize, Error> {
+        let bytes = self.collections.flush()?;
+        Ok(bytes)
+    }
+
+    /// Asynchronously flushes dirty IO buffers from the database.
+    /// Returns bytes flushed.
+    pub async fn async_flush(&self) -> Result<usize, Error> {
+        let bytes = self.collections.flush_async().await?;
+        Ok(bytes)
+    }
+
     #[cfg(feature = "py")]
     fn __len__(&self) -> usize {
         self.len()

--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -76,15 +76,14 @@ impl Database {
         self.count == 0
     }
 
-    /// Flushes dirty IO buffers from the database.
+    /// Flushes dirty IO buffers and syncs the data to disk.
     /// Returns bytes flushed.
     pub fn flush(&self) -> Result<usize, Error> {
         let bytes = self.collections.flush()?;
         Ok(bytes)
     }
 
-    /// Asynchronously flushes dirty IO buffers from the database.
-    /// Returns bytes flushed.
+    /// Asynchronously performs flush operation.
     pub async fn async_flush(&self) -> Result<usize, Error> {
         let bytes = self.collections.flush_async().await?;
         Ok(bytes)

--- a/src/func/collection.rs
+++ b/src/func/collection.rs
@@ -128,19 +128,15 @@ impl Index<&VectorID> for Collection {
     }
 }
 
-// This exposes Collection methods to Python.
-// Any modifications to these methods should be reflected in:
-// - py/tests/test_collection.py
-// - py/oasysdb/collection.pyi
-#[cfg_attr(feature = "py", pymethods)]
+// Python only methods.
+#[cfg(feature = "py")]
+#[pymethods]
 impl Collection {
-    #[cfg(feature = "py")]
     #[new]
     fn py_new(config: &Config) -> Self {
         Self::new(config)
     }
 
-    #[cfg(feature = "py")]
     #[staticmethod]
     fn from_records(
         config: &Config,
@@ -149,7 +145,6 @@ impl Collection {
         Self::build(config, &records)
     }
 
-    #[cfg(feature = "py")]
     #[staticmethod]
     #[pyo3(name = "build")]
     fn py_build(
@@ -159,6 +154,38 @@ impl Collection {
         Self::build(config, &records)
     }
 
+    #[getter(config)]
+    fn py_config(&self) -> Config {
+        self.config.clone()
+    }
+
+    #[getter(dimension)]
+    fn py_dimension(&self) -> usize {
+        self.dimension
+    }
+
+    #[setter(dimension)]
+    fn py_set_dimension(&mut self, dimension: usize) -> Result<(), Error> {
+        self.set_dimension(dimension)
+    }
+
+    #[getter(relevancy)]
+    fn py_relevancy(&self) -> f32 {
+        self.relevancy
+    }
+
+    #[setter(relevancy)]
+    fn py_set_relevancy(&mut self, relevancy: f32) {
+        self.relevancy = relevancy;
+    }
+}
+
+// This exposes Collection methods to both Python and Rust.
+// Any modifications to these methods should be reflected in:
+// - py/tests/test_collection.py
+// - py/oasysdb/collection.pyi
+#[cfg_attr(feature = "py", pymethods)]
+impl Collection {
     /// Inserts a vector record into the collection, and return `VectorID` if success.
     /// * `record`: Vector record to insert.
     pub fn insert(&mut self, record: &Record) -> Result<VectorID, Error> {
@@ -380,36 +407,6 @@ impl Collection {
         let mut res = self.truncate_irrelevant_result(sorted);
         res.truncate(n);
         Ok(res)
-    }
-
-    #[cfg(feature = "py")]
-    #[getter(config)]
-    fn py_config(&self) -> Config {
-        self.config.clone()
-    }
-
-    #[cfg(feature = "py")]
-    #[getter(dimension)]
-    fn py_dimension(&self) -> usize {
-        self.dimension
-    }
-
-    #[cfg(feature = "py")]
-    #[setter(dimension)]
-    fn py_set_dimension(&mut self, dimension: usize) -> Result<(), Error> {
-        self.set_dimension(dimension)
-    }
-
-    #[cfg(feature = "py")]
-    #[getter(relevancy)]
-    fn py_relevancy(&self) -> f32 {
-        self.relevancy
-    }
-
-    #[cfg(feature = "py")]
-    #[setter(relevancy)]
-    fn py_set_relevancy(&mut self, relevancy: f32) {
-        self.relevancy = relevancy;
     }
 
     /// Returns the number of vector records in the collection.

--- a/src/func/vector.rs
+++ b/src/func/vector.rs
@@ -60,40 +60,40 @@ impl From<VectorID> for usize {
 #[derive(PartialEq, PartialOrd)]
 pub struct Vector(pub Vec<f32>);
 
-// Methods available to Python.
-// If this implementation is modified, make sure to modify:
-// - py/tests/test_vector.py
-// - py/oasysdb/vector.pyi
-#[cfg_attr(feature = "py", pymethods)]
+// Methods available only to Python.
+#[cfg(feature = "py")]
+#[pymethods]
 impl Vector {
-    #[cfg(feature = "py")]
     #[new]
     fn py_new(vector: Vec<f32>) -> Self {
         vector.into()
     }
 
-    #[cfg(feature = "py")]
     fn to_list(&self) -> Vec<f32> {
         self.0.clone()
     }
 
-    #[cfg(feature = "py")]
     #[staticmethod]
     #[pyo3(name = "random")]
     fn py_random(dimension: usize) -> Self {
         Vector::random(dimension)
     }
 
-    #[cfg(feature = "py")]
     fn __repr__(&self) -> String {
         format!("{:?}", self)
     }
 
-    #[cfg(feature = "py")]
     fn __len__(&self) -> usize {
         self.len()
     }
+}
 
+// Methods available to both Python and Rust.
+// If this implementation is modified, make sure to modify:
+// - py/tests/test_vector.py
+// - py/oasysdb/vector.pyi
+#[cfg_attr(feature = "py", pymethods)]
+impl Vector {
     /// Returns the dimension of the vector.
     pub fn len(&self) -> usize {
         self.0.len()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![warn(unused_qualifications)]
 #![doc = include_str!("../readme.md")]
 #![doc(html_favicon_url = "https://i.postimg.cc/W3T230zk/favicon.png")]
 #![doc(html_logo_url = "https://i.postimg.cc/Vv0HPVwB/logo.png")]

--- a/src/tests/test_database.rs
+++ b/src/tests/test_database.rs
@@ -1,4 +1,5 @@
 use super::*;
+use futures::executor;
 
 #[test]
 fn new() {
@@ -49,4 +50,18 @@ fn delete_collection() {
     let mut db = create_test_database();
     db.delete_collection(NAME).unwrap();
     assert_eq!(db.len(), 0);
+}
+
+#[test]
+fn flush() {
+    let db = create_test_database();
+    let bytes = db.flush().unwrap();
+    assert!(bytes > 0);
+}
+
+#[test]
+fn async_flush() {
+    let db = create_test_database();
+    let bytes = executor::block_on(db.async_flush()).unwrap();
+    assert!(bytes > 0);
 }


### PR DESCRIPTION
### Purpose

This PR tries to solve the issue mention in issue #79 and discussion #77 where the database size on disk is overly large due repeated saving the collection causing all of the IO buffers to pile up.

### Approach

This PR adds `flush` and `async_flush` method to the database struct.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

Added 2 new tests for both Python and Rust test suites to test the flushes functionalities.

### Chore checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added comments to most of my code, particularly in hard-to-understand areas.
