### PR TITLE
feat: save collection to disk via file write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "oasysdb"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oasysdb"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "readme.md"

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -56,7 +56,7 @@ I made this decision to make the indexing algorithm more efficient and performan
 
 By default, due to the nature of the vector indexing algorithm, OasysDB stores the vector record data in memory via the collection interface. This means that unless persisted to disk via the database save collection method, the data will be lost when the program is closed.
 
-Under the hood, OasysDB serializes the collection using [Serde](https://github.com/serde-rs/serde) and saves it to the database file using [Sled](https://github.com/spacejam/sled). Because of this, **whenever you modify a collection, you need to save the collection back to the database to persist the changes to disk.**
+Under the hood, OasysDB serializes the collection to bytes using [Serde](https://github.com/serde-rs/serde) and writes it to a file. The reference to the file is then saved, along with other details, to the database powered by [Sled](https://github.com/spacejam/sled). Because of this, **whenever you modify a collection, you need to save the collection back to the database to persist the changes to disk.**
 
 When opening the database, OasysDB doesn't automatically load the collections from the database file into memory as this would be inefficient if you have many collections you don't necessarily use all the time. Instead, you need to load the collections you want to use into memory manually using the get collection method.
 

--- a/docs/migrations/0.4.5-to-0.5.0.md
+++ b/docs/migrations/0.4.5-to-0.5.0.md
@@ -1,0 +1,66 @@
+# Migrating from v0.4.5 to v0.5.0
+
+Due to the breaking changes introduced in v0.5.0 on the persistence system, you might need to update your codebase to make it compatible with the new version. This is not required if you are starting a new project from scratch.
+
+### What happened?
+
+In v0.5.0, we introduced a new persistence system that is more optimized for rapidly changing data. Previously, we were using Sled to store the serialized collection blobs. We found that it was not the best option for our use case as each blob size could be somewhere in between 100MB to 10GB.
+
+With rapid changes in the collection data, users need to reserialize and rewrite the entire blob back to Sled. This caused some storage issues bloating the disk space up to 100x the blob size.
+
+This new system is more optimized for our use case since we now write the serialized collection data directly to a dedicated file on the disk. We, now, only use Sled for storing the metadata and the file paths to the collection.
+
+## How to migrate?
+
+To migrate OasysDB from v0.4.5 to v0.5.0, I recommend creating a new Rust project and migrating the database from there. This migration project will read the data from the old database and write them to the new database. And for that, this project need to have access to the database files.
+
+If you are using OasysDB on Python, you might want to use Rust to migrate the database as it supports installing both versions of OasysDB on the same project easily.
+
+Note: Make sure to create a back-up of your database files before proceeding.
+
+### 1. Install both versions of OasysDB
+
+After setting up the new project, you can install both versions of OasysDB by specifying the version in the `Cargo.toml`.
+
+```toml
+[dependencies]
+odb4 = { package = "oasysdb", version = "0.4.5" }
+odb5 = { package = "oasysdb", version = "0.5.0" }
+```
+
+### 2. Migrate the database
+
+You can now write a Rust script to read the data from the old database and write them to the new database. Here is an example script that reads the data from the old database and writes them to the new database.
+
+```rust
+use odb4::prelude::Database;
+use odb5::prelude::Database as NewDatabase;
+
+fn main() {
+    // Change the path to the database accordingly.
+    let db = Database::open("database").unwrap();
+    let mut new_db = NewDatabase::new("new-database").unwrap();
+
+    // Collection names you want to migrate.
+    let names = vec!["collection_a", "collection_b"];
+
+    // This will read the collections from the old
+    // database and write them to the new database.
+    for name in names {
+        let collection = db.get_collection(name).unwrap();
+        new_db.save_collection(name, &collection).unwrap();
+    }
+}
+```
+
+### 3. Verify the migration
+
+After running the script, you can verify the migration by checking the new database files. The new database path should contain a sub-directory called `collections` which stores the serialized collection data. The number of files in this directory should be equal to the number of collections you migrated.
+
+Don't forget to point your application to the new database path after the migration or rename the new database path to the old database path to make sure that your application uses the new database.
+
+## Conclusion
+
+If all the steps are followed correctly, you should have successfully migrated your OasysDB database from v0.4.5 to v0.5.0. If you face any issues during the migration, feel free to reach out to me via our [Discord](https://discord.gg/bDhQrkqNP4).
+
+I will be happy to personally assist you with the migration process 😁

--- a/docs/migrations/0.4.5-to-0.5.0.md
+++ b/docs/migrations/0.4.5-to-0.5.0.md
@@ -16,7 +16,7 @@ To migrate OasysDB from v0.4.5 to v0.5.0, I recommend creating a new Rust projec
 
 If you are using OasysDB on Python, you might want to use Rust to migrate the database as it supports installing both versions of OasysDB on the same project easily.
 
-Note: Make sure to create a back-up of your database files before proceeding.
+**Friendly Reminder**: Make sure to create a back-up of your database files before proceeding 😉
 
 ### 1. Install both versions of OasysDB
 

--- a/docs/migrations/0.4.5-to-0.5.0.md
+++ b/docs/migrations/0.4.5-to-0.5.0.md
@@ -6,21 +6,21 @@ Due to the breaking changes introduced in v0.5.0 on the persistence system, you 
 
 In v0.5.0, we introduced a new persistence system that is more optimized for rapidly changing data. Previously, we were using Sled to store the serialized collection blobs. We found that it was not the best option for our use case as each blob size could be somewhere in between 100MB to 10GB.
 
-With rapid changes in the collection data, users need to reserialize and rewrite the entire blob back to Sled. This caused some storage issues bloating the disk space up to 100x the blob size.
+When the data change rapidly, the collections need to be saved periodically to avoid data loss. With this, the collections need to be reserialized and rewritten back into Sled. The dirty IO buffer during these operations caused some storage issues, bloating the space required to store the collection for up to 100x the collection size.
 
-This new system is more optimized for our use case since we now write the serialized collection data directly to a dedicated file on the disk. We, now, only use Sled for storing the metadata and the file paths to the collection.
+This new system is more optimized for our use case since we now write the serialized collection data directly to a dedicated file on the disk. Now, we only use Sled for storing the collection metadata and the path to where the collection is stored.
 
 ## How to migrate?
 
 To migrate OasysDB from v0.4.5 to v0.5.0, I recommend creating a new Rust project and migrating the database from there. This migration project will read the data from the old database and write them to the new database. And for that, this project need to have access to the database files.
 
-If you are using OasysDB on Python, you might want to use Rust to migrate the database as it supports installing both versions of OasysDB on the same project easily.
+If you are using OasysDB on Python, you might want to use Rust to migrate the database as it supports installing both versions of OasysDB on the same project easily which is required for the migration. I can promise you that the migration process is quite simple and straightforward.
 
 **Friendly Reminder**: Make sure to create a back-up of your database files before proceeding 😉
 
 ### 1. Install both versions of OasysDB
 
-After setting up the new project, you can install both versions of OasysDB by specifying the version in the `Cargo.toml`.
+After setting up the new project, you can install both versions of OasysDB by specifying the package and the version in the `Cargo.toml` file.
 
 ```toml
 [dependencies]
@@ -30,7 +30,7 @@ odb5 = { package = "oasysdb", version = "0.5.0" }
 
 ### 2. Migrate the database
 
-You can now write a Rust script to read the data from the old database and write them to the new database. Here is an example script that reads the data from the old database and writes them to the new database.
+The following script will read the collections from the old database and write them to the new database which is all we need to do to migrate the database.
 
 ```rust
 use odb4::prelude::Database;
@@ -57,10 +57,10 @@ fn main() {
 
 After running the script, you can verify the migration by checking the new database files. The new database path should contain a sub-directory called `collections` which stores the serialized collection data. The number of files in this directory should be equal to the number of collections you migrated.
 
-Don't forget to point your application to the new database path after the migration or rename the new database path to the old database path to make sure that your application uses the new database.
+Don't forget to point your application to the new database path after the migration or rename the new database path to the old database path to make sure that your application uses the new database correctly.
 
 ## Conclusion
 
-If all the steps are followed correctly, you should have successfully migrated your OasysDB database from v0.4.5 to v0.5.0. If you face any issues during the migration, feel free to reach out to me via our [Discord](https://discord.gg/bDhQrkqNP4).
+If all the steps are followed correctly, you should have successfully migrated your OasysDB database from v0.4.5 to v0.5.0. If you face any issues during the migration, feel free to reach out to me on our [Discord](https://discord.gg/bDhQrkqNP4).
 
 I will be happy to personally assist you with the migration process 😁

--- a/readme.md
+++ b/readme.md
@@ -32,17 +32,23 @@ OasysDB is very flexible! You can use it for systems related with vector similar
 
 ### Core Features
 
-🔸 **Embedded Database**: Zero setup & no server required.\
-🔸 **Optional Persistence**: In-memory or disk-based collection.\
-🔸 **Incremental Ops**: Modify vectors without rebuilding indexes.\
-🔸 **Flexible Schema**: Store additional metadata for each vector.
+🔸 **Embedded Database**: Zero setup and no dedicated server or process required.
+
+🔸 **Optional Persistence**: In-memory vector collections that can be persisted to disk.
+
+🔸 **Incremental Ops**: Insert, modify, and delete vectors without rebuilding indexes.
+
+🔸 **Flexible Schema**: Store additional and flexible metadata for each vector record.
 
 ### Technical Features
 
-🔹 **Fast HNSW**: Efficient approximate vector similarity search.\
-🔹 **Configurable Metric**: Use Euclidean, Cosine, or other metric.\
-🔹 **Parallel Processing**: Multi-threaded & SIMD optimized calculation.\
-🔹 **Built-in Incremental ID**: No headache vector record management.
+🔹 **Fast HNSW**: Efficient vector similarity search with state-of-the-art algorithm.
+
+🔹 **Configurable Metric**: Use Euclidean, Cosine, or other metric for your specific use-case.
+
+🔹 **Parallel Processing**: Multi-threaded & SIMD-optimized vector distance calculation.
+
+🔹 **Built-in Incremental ID**: No headache record management and efficient storage.
 
 ## Design Philosophy
 
@@ -120,6 +126,14 @@ fn main() {
     println!("{}", data);
 }
 ```
+
+## Feature Flags
+
+OasysDB provides several feature flags to enable or disable certain features. You can do this by adding the feature flags to your project `Cargo.toml` file. Below are the available feature flags and their descriptions:
+
+- `json`: Enables easy Serde's JSON conversion from and to the metadata type. This feature is very useful if you have a complex metadata type or if you use APIs that communicate using JSON.
+
+- `gen`: Enables the vector generator trait and modules to extract vector embeddings from your contents using OpenAI or other embedding models. This feature allows OasysDB to handle vector embedding extraction for you without separate dependencies.
 
 # 🚀 Quickstart with Python
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,7 +4,9 @@ pub mod database;
 use crate::collection::*;
 use crate::func::err::Error;
 use sled::Db;
-use std::fs::remove_dir_all;
+use std::fs::{create_dir_all, remove_dir_all, remove_file, OpenOptions};
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
 
 #[cfg(feature = "py")]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3,11 +3,13 @@ pub mod database;
 
 use crate::collection::*;
 use crate::func::err::Error;
+use serde::{Deserialize, Serialize};
 use sled::Db;
 use std::fs::{create_dir_all, remove_dir_all, remove_file, OpenOptions};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(feature = "py")]
 use pyo3::prelude::*;

--- a/src/func/err.rs
+++ b/src/func/err.rs
@@ -1,9 +1,11 @@
+use std::fmt::{Display, Formatter, Result};
+
 // Other error types.
 use bincode::ErrorKind as BincodeError;
 use sled::Error as SledError;
 use std::error::Error as StandardError;
-use std::fmt::{Display, Formatter, Result};
 use std::io::Error as IOError;
+use std::string::FromUtf8Error as StringError;
 
 #[cfg(feature = "py")]
 use super::*;
@@ -130,6 +132,13 @@ impl From<IOError> for Error {
 
 impl From<Box<BincodeError>> for Error {
     fn from(err: Box<BincodeError>) -> Self {
+        let kind = ErrorKind::SerializationError;
+        Error::new(&kind, &err.to_string())
+    }
+}
+
+impl From<StringError> for Error {
+    fn from(err: StringError) -> Self {
         let kind = ErrorKind::SerializationError;
         Error::new(&kind, &err.to_string())
     }

--- a/src/func/err.rs
+++ b/src/func/err.rs
@@ -5,7 +5,6 @@ use bincode::ErrorKind as BincodeError;
 use sled::Error as SledError;
 use std::error::Error as StandardError;
 use std::io::Error as IOError;
-use std::string::FromUtf8Error as StringError;
 
 #[cfg(feature = "py")]
 use super::*;
@@ -132,13 +131,6 @@ impl From<IOError> for Error {
 
 impl From<Box<BincodeError>> for Error {
     fn from(err: Box<BincodeError>) -> Self {
-        let kind = ErrorKind::SerializationError;
-        Error::new(&kind, &err.to_string())
-    }
-}
-
-impl From<StringError> for Error {
-    fn from(err: StringError) -> Self {
         let kind = ErrorKind::SerializationError;
         Error::new(&kind, &err.to_string())
     }


### PR DESCRIPTION
### Purpose & approach

This PR is purposed to fix the issue #79 by replacing the previous internal implementaion of database methods that directly stored and retrieved serialized vector collections to Sled with writing and reading them from a file.

After talking to the maintainers of Sled, it makes sense that Sled is not built to store `Collection` due to its size reaching 100MB to 10GB per collection. Instead now, OasysDB database serialize and store collections directly into files.

The file reference to where the collection is stored is now packaged in `CollectionRecord` along with other utility details like collection length and time the database is created and updated.


### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

This PR doesn't change how the API works to change the test. But this PR is not compatible with the previous release.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
- [x] Add a migration guide to the docs.