### PR TITLE
fix: called option unwrap on a none value on insert

### DIFF
--- a/src/func/utils.rs
+++ b/src/func/utils.rs
@@ -393,14 +393,10 @@ impl<'a> IndexConstruction<'a> {
         insertion.ef = self.config.ef_construction;
 
         // Find the first valid vector ID to push.
-        let validator = |i: usize| self.vectors.get(&i.into()).is_some();
-        let valid_id = (0..self.vectors.len())
-            .into_par_iter()
-            .find_first(|i| validator(*i))
-            .unwrap();
+        let valid_id = self.vectors.keys().next().unwrap();
 
         search.reset();
-        search.push(&valid_id.into(), vector, self.vectors);
+        search.push(valid_id, vector, self.vectors);
 
         for current_layer in self.top_layer.descend() {
             search.ef = self.config.ef_construction;

--- a/src/func/utils.rs
+++ b/src/func/utils.rs
@@ -393,10 +393,14 @@ impl<'a> IndexConstruction<'a> {
         insertion.ef = self.config.ef_construction;
 
         // Find the first valid vector ID to push.
-        let valid_id = self.vectors.keys().next().unwrap();
+        let validator = |i: u32| self.vectors.get(&i.into()).is_some();
+        let valid_id = (0..u32::MAX)
+            .into_par_iter()
+            .find_first(|i| validator(*i))
+            .unwrap_or(0);
 
         search.reset();
-        search.push(valid_id, vector, self.vectors);
+        search.push(&valid_id.into(), vector, self.vectors);
 
         for current_layer in self.top_layer.descend() {
             search.ef = self.config.ef_construction;


### PR DESCRIPTION
### Purpose

This PR fixes a bug that happens when attempting to insert a new vector record to the collection but the collection can't find the first valid vector ID to start the insert operation.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

The script below will reproduce the issue with the previous version:

```rs
use oasysdb::prelude::*;

fn main() {
    let config = Config::default();
    let mut collection = Collection::new(&config);
    let record = Record::many_random(1536, 2);

    // Insert and delete a record
    collection.insert(&record[0]).unwrap();
    collection.delete(&VectorID(0)).unwrap();

    // Insert another record
    collection.insert(&record[1]).unwrap();
}
```

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
