### PR TITLE
feat: add bool metadata

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -38,6 +38,7 @@ When you want to store a vector in OasysDB, you will insert vector record object
 
 - Text
 - Number
+- Boolean
 - Array
 - Object
 

--- a/py/oasysdb/collection.pyi
+++ b/py/oasysdb/collection.pyi
@@ -60,6 +60,7 @@ class Record:
     Metadata types:
     - String
     - Number
+    - Boolean
     - List of metadata types
     - Dictionary of metadata types
     """

--- a/src/tests/test_metadata.rs
+++ b/src/tests/test_metadata.rs
@@ -27,3 +27,23 @@ fn metadata_to_json_value() {
 
     assert_eq!(value, value_from_metadata);
 }
+
+#[cfg(feature = "json")]
+#[test]
+fn insert_data_type_json() {
+    let mut collection = create_collection();
+
+    let data = json!({
+        "number": 1,
+        "boolean": true,
+        "string": "text",
+    });
+
+    // Create a new record with JSON data.
+    let vector = Vector::random(DIMENSION);
+    let new_record = Record::new(&vector, &data.clone().into());
+    let id = collection.insert(&new_record).unwrap();
+
+    let metadata = Metadata::from(data);
+    assert_eq!(collection.get(&id).unwrap().data, metadata);
+}


### PR DESCRIPTION
### Purpose

This PR adds boolean metadata type with its corresponding type conversion to JSON, PyO3, and Rust primitive types.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

I added a new test to store a more complex JSON data containing multiple different value types.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
