### PR TITLE
fix: atomic collection file writes

### DIFF
--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -264,8 +264,8 @@ impl Database {
         let collections_dir = Path::new(path).join(COLLECTIONS_DIR);
         let temp_dir = Path::new(path).join(TMP_DIR);
         if !collections_dir.exists() {
-            fs::create_dir_all(&collections_dir)?;
-            fs::create_dir_all(&temp_dir)?;
+            fs::create_dir_all(collections_dir)?;
+            fs::create_dir_all(temp_dir)?;
         }
 
         Ok(())

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -8,7 +8,7 @@ use sled::Db;
 use std::collections::hash_map::DefaultHasher;
 use std::fs::{self, OpenOptions};
 use std::hash::{Hash, Hasher};
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter, Read};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,11 +2,11 @@
 pub mod database;
 
 use crate::collection::*;
-use crate::func::err::Error;
+use crate::func::err::{Error, ErrorKind};
 use serde::{Deserialize, Serialize};
 use sled::Db;
 use std::collections::hash_map::DefaultHasher;
-use std::fs::{create_dir_all, remove_dir_all, remove_file, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::hash::{Hash, Hasher};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;


### PR DESCRIPTION
### Purpose

As desribe in issue #98

This PR makes save_collection atomic to prevent corruption in the case of failure.

### Testing

- [x] I have tested this PR locally.
- [x] I added tests to cover my changes, if not applicable, I have added a reason why.

There is no change in API. So, there is no additional test needed.

### Chore checklist

- [x] I have updated the documentation accordingly.
- [x] I have added comments to most of my code, particularly in hard-to-understand areas.
