### PR TITLE
fix: ensure oasysdb works well with postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +50,21 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -471,6 +495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +538,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -666,6 +702,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,8 +787,18 @@ dependencies = [
  "simsimd",
  "sqlx",
  "tar",
+ "tokio",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "object"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -963,6 +1021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1232,8 @@ dependencies = [
  "smallvec",
  "sqlformat",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "tracing",
  "url",
 ]
@@ -1207,6 +1273,7 @@ dependencies = [
  "sqlx-sqlite",
  "syn 1.0.109",
  "tempfile",
+ "tokio",
  "url",
 ]
 
@@ -1409,6 +1476,32 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ categories = ["database", "algorithms", "embedded"]
 [dependencies]
 uuid = { version = "1.9.1", features = ["v4", "fast-rng", "serde"] }
 half = { version = "2.4.1", features = ["serde"] }
+tokio = { version = "1.39.2", features = ["rt-multi-thread"] }
 url = "2.5.2"
 futures = "0.3.30"
 rand = "0.8.5"
@@ -34,7 +35,7 @@ serde_json = "1.0.120"
 [dependencies.sqlx]
 version = "0.7.4"
 default-features = false
-features = ["all-databases"]
+features = ["all-databases", "runtime-tokio"]
 
 [dev-dependencies]
 byteorder = "1.5.0"

--- a/examples/measure_recall.rs
+++ b/examples/measure_recall.rs
@@ -1,7 +1,7 @@
 use common::Dataset;
-use futures::executor;
 use oasysdb::prelude::*;
 use std::error::Error;
+use tokio::runtime::Runtime;
 
 mod common;
 
@@ -10,7 +10,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db_url = dataset.database_url();
     let config = SourceConfig::new(dataset.name(), "id", "vector");
 
-    executor::block_on(dataset.populate_database())?;
+    let rt = Runtime::new()?;
+    rt.block_on(dataset.populate_database())?;
 
     let db = Database::open("odb_example", Some(db_url))?;
     create_index_flat(&db, &config)?;


### PR DESCRIPTION
### Purpose

Fix an issue that hinder OasysDB to interact with PostgreSQL due to async runtime.

### Approach

We enable Tokio runtime for SQLx and use Tokio to execute OasysDB async functions.

### Testing

- [x] I have tested this PR locally.
- [x] If applicable, I added tests to cover my changes.

Using the `measure_recall.rs` example:

1. Change the source database from SQLite to Postgres.
2. Modify some of the SQL queries for SQLite to Postgres.
3. Run the example with successful result.

### Chore Checklist

- [x] I formatted my code according to the style and linter guidelines.
- [x] If applicable, I updated the documentation accordingly.
